### PR TITLE
perl 5.18 doesn't produce "syntax error", allow for that

### DIFF
--- a/t/app/030-app-base.t
+++ b/t/app/030-app-base.t
@@ -212,7 +212,7 @@ use Test::Smoke::App::AppOption;
     isa_ok($app, 'Test::Smoke::App::Test1');
     like(
         $app->configfile_error,
-        qr/syntax error/,
+        qr/syntax error|Unknown regexp modifier/,
         "configfile error"
     );
     unlink 'smokeme.config';


### PR DESCRIPTION
It instead produces:

Unknown regexp modifier "/b" at smokeme.config line 1, at end of line
Unknown regexp modifier "/n" at smokeme.config line 1, at end of line
