### PR TITLE
Using the syncer as configured by `configuresmoke.pl`

### DIFF
--- a/lib/Test/Smoke/App/SyncTree.pm
+++ b/lib/Test/Smoke/App/SyncTree.pm
@@ -50,8 +50,9 @@ sub new {
     my $class = shift;
     my $self = $class->SUPER::new(@_);
 
+    my $syncer = $self->{_final_options}->{sync_type} || $self->option('syncer');
     $self->{_syncer} = Test::Smoke::Syncer->new(
-        $self->option('syncer'),
+	$syncer,
         $self->options,
         v => $self->option('verbose'),
     );


### PR DESCRIPTION
When running smokecurrent.sh, the default syncer (at present 'git', as
returned by the `syncer()` method in `Test::Smoke::App:Options`) is used instead
of that configured by using `configuresmoke.pl`.  This change implements a
hack (i.e. I'm not 100% sure this is the right place to put this change,
however can't find the appropriate place to update the 'syncer'
configuration value).  The fundamental problem is that the 'sync_type'
option (set in the `_final_options` part of the entire configuration) doesn't
override the default 'syncer' option.  Interestingly enough, the 'sync_type'
option is used when instantiating the `Test::Smoke::Syncer` object in
`tssynctree.pl`.  This change thus makes the behaviour of both `tssmokeperl.pl`
and `tssynctree.pl` consistent.