### PR TITLE
Creating download dir for rsync syncer

### DIFF
--- a/lib/Test/Smoke/Syncer/Rsync.pm
+++ b/lib/Test/Smoke/Syncer/Rsync.pm
@@ -46,6 +46,10 @@ sub sync {
     my $redir = $self->{v} ? "" : " >" . File::Spec->devnull;
 
     my $cwd = cwd();
+    if (not -e $self->{ddir}) {
+	use File::Path qw(make_path);
+	make_path($self->{ddir});
+    }
     chdir $self->{ddir} or do {
         require Carp;
         Carp::croak( "[rsync] Cannot chdir($self->{ddir}): $!" );


### PR DESCRIPTION
When the rsync option is selected for synchronisation, the download
directory (ddir) isn't created, and thus rsync exits with a "No such file or
directory" error.  This change ensures that the directory is created before
the (initial) rsync takes place.