### PR TITLE
Remove trailing whitespace

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -176,7 +176,7 @@ sub dir_prompt {
 
         # thanks to perlfaq5
         $dir =~ s{^ ~ ([^/]*)}
-                 {$1 ? ( getpwnam $1 )[7] : 
+                 {$1 ? ( getpwnam $1 )[7] :
                        ( $ENV{HOME} || $ENV{LOGDIR} ||
                          "$ENV{HOMEDRIVE}$ENV{HOMEPATH}" )
                  }ex;

--- a/W32Configure.pl
+++ b/W32Configure.pl
@@ -73,7 +73,7 @@ Just pass it options for the F<Makefile> on the command-line.
 See L<Test::Smoke::Util/Configure_win32> for options you can pass!
 
 The result is B<[builddir]\win32\smoke.mk> a makefile that has all
-the configure options you passed worked into it. 
+the configure options you passed worked into it.
 
 This could help debugging.
 
@@ -107,14 +107,14 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }
 
 $opt{maker} ||= 'nmake';
 $opt{ddir} && -d $opt{ddir} or
-    do_pod2usage( message => "'$opt{ddir}' does not exist!", 
+    do_pod2usage( message => "'$opt{ddir}' does not exist!",
                   verbose => 0, myusage => $my_usage );
 
 push @ARGV, "-DCCTYPE=$conf->{w32cc}" unless grep /^-DCCTYPE=/ => @ARGV;

--- a/archiverpt.pl
+++ b/archiverpt.pl
@@ -105,7 +105,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }

--- a/inc/Mail/Sendmail.pm
+++ b/inc/Mail/Sendmail.pm
@@ -311,7 +311,7 @@ sub sendmail {
     if (/^[45]/ or !$_) {
         return fail("HELO error ($_)")
     }
-    
+
     print S "mail from: <$fromaddr>\015\012";
     chomp($_ = <S>);
     if (/^[45]/ or !$_) {
@@ -423,7 +423,7 @@ Copy Sendmail.pm to Mail/ in your Perl lib directory.
 
 ppm install --location=http://alma.ch/perl/ppm Mail-Sendmail
 
-But this way you don't get a chance to have a look at other files (Changes, 
+But this way you don't get a chance to have a look at other files (Changes,
 Todo, test.pl, ...) and PPM doesn't run the test script (test.pl).
 
 =back
@@ -435,7 +435,7 @@ Install MIME::QuotedPrint. This is not required but strongly recommended.
 
 =head1 FEATURES
 
-Automatic time zone detection, Date: header, MIME quoted-printable encoding 
+Automatic time zone detection, Date: header, MIME quoted-printable encoding
 (if MIME::QuotedPrint installed), all of which can be overridden.
 
 Internal Bcc: and Cc: support (even on broken servers)
@@ -456,7 +456,7 @@ Doesn't work on OpenVMS.
 
 Headers are not encoded, even if they have accented characters.
 
-Since the whole message is in memory (twice!), it's not suitable for 
+Since the whole message is in memory (twice!), it's not suitable for
 sending very big attached files.
 
 The SMTP server has to be set manually in Sendmail.pm or in your script,
@@ -660,9 +660,9 @@ The package version number (you can not import this one)
 
 =head2 Configuration variables from previous versions
 
-The following global variables were used in version 0.74 for configuration. 
-They should still work, but will not in a future version (unless you 
-complain loudly). Please use I<%mailcfg> if you need to access the 
+The following global variables were used in version 0.74 for configuration.
+They should still work, but will not in a future version (unless you
+complain loudly). Please use I<%mailcfg> if you need to access the
 configuration from your scripts.
 
 =over 4
@@ -728,13 +728,13 @@ Milivoj Ivkovic mi@alma.ch or ivkovic@bluewin.ch
 
 =head1 NOTES
 
-MIME::QuotedPrint is used by default on every message if available. It 
-allows reliable sending of accented characters, and also takes care of 
-too long lines (which can happen in HTML mails). It is available in the 
-MIME-Base64 package at http://www.perl.com/CPAN/modules/by-module/MIME/ or 
+MIME::QuotedPrint is used by default on every message if available. It
+allows reliable sending of accented characters, and also takes care of
+too long lines (which can happen in HTML mails). It is available in the
+MIME-Base64 package at http://www.perl.com/CPAN/modules/by-module/MIME/ or
 through PPM.
 
-Look at http://alma.ch/perl/Mail-Sendmail-FAQ.htm for additional info 
+Look at http://alma.ch/perl/Mail-Sendmail-FAQ.htm for additional info
 (CGI, examples of sending attachments, HTML mail etc...)
 
 You can use it freely. (Someone complained this is too vague. So, more

--- a/lib/Test/Smoke.pm
+++ b/lib/Test/Smoke.pm
@@ -28,8 +28,8 @@ Test::Smoke - The Perl core test smoke suite
     use vars qw( $VERSION );
     $VERSION = Test::Smoke->VERSION;
 
-    read_config( $config_name ) or warn Test::Smoke->config_error; 
-    
+    read_config( $config_name ) or warn Test::Smoke->config_error;
+
 
 =head1 DESCRIPTION
 
@@ -46,9 +46,9 @@ Read (require) the configfile.
 sub read_config {
     my( $config_name ) = @_;
 
-    $config_name = 'smokecurrent_config' 
+    $config_name = 'smokecurrent_config'
         unless defined $config_name && length $config_name;
-    $config_name .= '_config' 
+    $config_name .= '_config'
         unless $config_name =~ /_config$/ || -f $config_name;
 
     # Enable reloading by hackery
@@ -79,7 +79,7 @@ sub is_win32() { $^O eq "MSWin32" }
 
 =head2 do_manifest_check( $ddir, $smoker )
 
-C<do_manifest_check()> uses B<Test::Smoke::SourceTree> to do the 
+C<do_manifest_check()> uses B<Test::Smoke::SourceTree> to do the
 MANIFEST check.
 
 =cut
@@ -117,7 +117,7 @@ sub set_smoke_patchlevel {
 =head2 run_smoke( [$continue[, @df_buildopts]] )
 
 C<run_smoke()> sets up de build environment and gets the private Policy
-file and build configurations and then runs the smoke stuff for all 
+file and build configurations and then runs the smoke stuff for all
 configurations.
 
 All arguments after the C<$continue> are taken as default buildoptions
@@ -131,7 +131,7 @@ sub run_smoke {
 
     my @df_buildopts = @_ ? grep /^-[DUA]/ => @_ : ();
     # We *always* want -Dusedevel!
-    push @df_buildopts, '-Dusedevel' 
+    push @df_buildopts, '-Dusedevel'
         unless grep /^-Dusedevel$/ => @df_buildopts;
     Test::Smoke::BuildCFG->config( dfopts => join " ", @df_buildopts );
 
@@ -147,8 +147,8 @@ sub run_smoke {
     }
 
     my $logfile = File::Spec->catfile( $conf->{ddir}, 'mktest.out' );
-    my $BuildCFG = $continue 
-        ? Test::Smoke::BuildCFG->continue( $logfile, $conf->{cfg}, 
+    my $BuildCFG = $continue
+        ? Test::Smoke::BuildCFG->continue( $logfile, $conf->{cfg},
                                            v => $conf->{v} )
         : Test::Smoke::BuildCFG->new( $conf->{cfg}, v => $conf->{v} );
 
@@ -176,7 +176,7 @@ sub run_smoke {
     chdir $conf->{ddir} or die "Cannot chdir($conf->{ddir}): $!";
     unless ( $continue ) {
         $smoker->make_distclean( );
-        $smoker->ttylog("Smoking patch $patch->[0] $patch->[1]\n"); 
+        $smoker->ttylog("Smoking patch $patch->[0] $patch->[1]\n");
         $smoker->ttylog("Smoking branch $patch->[2]\n") if $patch->[2];
         do_manifest_check( $conf->{ddir}, $smoker );
         set_smoke_patchlevel( $conf->{ddir}, $patch->[0] );
@@ -189,7 +189,7 @@ sub run_smoke {
             next;
         }
 
-        $smoker->ttylog( join "\n", 
+        $smoker->ttylog( join "\n",
                               "", "Configuration: $this_cfg", "-" x 78, "" );
         $smoker->smoke( $this_cfg, $Policy );
     }

--- a/lib/Test/Smoke/App/Base.pm
+++ b/lib/Test/Smoke/App/Base.pm
@@ -49,7 +49,7 @@ Test::Smoke::App::Base - Baseclass for Test::Smoke::App::* applications.
             'sendmail' => [],
         },
     );
-  
+
   $mailer->run();
 
 =head2 Test::Smoke::App->new(%arguments)

--- a/lib/Test/Smoke/Archiver.pm
+++ b/lib/Test/Smoke/Archiver.pm
@@ -88,7 +88,7 @@ sub archive_files {
     if (!$self->adir) {
         return $self->log_info("Skipping archive: No archive directory set.");
     }
-    
+
     if (!-d $self->adir) {
         mkpath($self->adir, ($self->v > 1), 0775)
             or die "Cannot mkpath(@{[$self->adir]}): $!";

--- a/lib/Test/Smoke/BuildCFG.pm
+++ b/lib/Test/Smoke/BuildCFG.pm
@@ -105,7 +105,7 @@ sub continue {
 
 [ Accessor | Public ]
 
-C<config()> is an interface to the package lexical C<%CONFIG>, 
+C<config()> is an interface to the package lexical C<%CONFIG>,
 which holds all the default values for the C<new()> arguments.
 
 With the special key B<all_defaults> this returns a reference
@@ -202,7 +202,7 @@ sub _read {
         } else { # Allow intentional default_buildcfg()
             $self->{_buildcfg} = $self->default_buildcfg();
             $vmsg = "internal content";
-        } 
+        }
     }
     $vmsg .= "[continue]" if $self->{_continue};
     $self->{v} and print "Reading build configurations from $vmsg\n";
@@ -221,8 +221,8 @@ There are two types of section
 
 =item B<policy-section>
 
-A B<policy-section> contains a "target-option". This is a build option 
-that should be in the ccflags variable in the F<Policy.sh> file 
+A B<policy-section> contains a "target-option". This is a build option
+that should be in the ccflags variable in the F<Policy.sh> file
 (see also L<Test::Smoke::Policy>) and starts with a (forward) slash ('/').
 
 A B<policy-section> can have only one (1) target-option.
@@ -263,28 +263,28 @@ sub _parse {
                             join( "\n\t", @targets ),
                             "\nWill use /$targets[0]/\n" );
             }
-            push @{ $self->{_sections} }, 
-                 { policy_target => $targets[0], 
+            push @{ $self->{_sections} },
+                 { policy_target => $targets[0],
                    args => [ sort {$opts{ $a } <=> $opts{ $b }} keys %opts ] };
 
         } else { # Buildopt section
-            push @{ $self->{_sections} }, 
+            push @{ $self->{_sections} },
                  [ sort {$opts{ $a } <=> $opts{ $b }} keys %opts ];
         }
     }
     # Make sure we have at least *one* section
     push @{ $self->{_sections} }, [ "" ] unless @{ $self->{_sections} };
 
-    $self->{v} > 1 and printf "Left with %d parsed sections\n", 
+    $self->{v} > 1 and printf "Left with %d parsed sections\n",
                               scalar @{ $self->{_sections} };
     $self->_serialize;
-    $self->{v} > 1 and printf "Found %d (unfiltered) configurations\n", 
+    $self->{v} > 1 and printf "Found %d (unfiltered) configurations\n",
                               scalar @{ $self->{_list} };
 }
 
 =item $self->_serialize( )
 
-C<_serialize()> creates a list of B<Test::Smoke::BuildCFG::Config> 
+C<_serialize()> creates a list of B<Test::Smoke::BuildCFG::Config>
 objects from the parsed sections.
 
 =cut
@@ -318,7 +318,7 @@ sub __build_list {
         $config_args .= " $conf" if length $conf;
 
         my @substitutions = @$policy_subst;
-        push @substitutions, [ $policy_target, $conf ] 
+        push @substitutions, [ $policy_target, $conf ]
             if defined $policy_target;
 
         if ( @cfgs ) {
@@ -356,8 +356,8 @@ sub policy_targets {
     return unless UNIVERSAL::isa( $self->{_sections}, "ARRAY" );
 
     my @targets;
-    for my $section ( @{ $self->{_sections} } ) { 
-        next unless UNIVERSAL::isa( $section, "HASH" ) && 
+    for my $section ( @{ $self->{_sections} } ) {
+        next unless UNIVERSAL::isa( $section, "HASH" ) &&
                     $section->{policy_target};
         push @targets, $section->{policy_target};
     }
@@ -415,7 +415,7 @@ sub __get_smoked_configs {
 
 =item Test::Smoke::BuildCFG->default_buildcfg()
 
-This is a constant that returns a textversion of the default 
+This is a constant that returns a textversion of the default
 configuration.
 
 =cut
@@ -477,7 +477,7 @@ or
 
     my $bcfg = Test::Smoke::BuildCFG::Config->new;
     $bcfg->args( $args );
-    $bcfg->policy( [ -DDEBUGGING => '-DDEBUGGING' ], 
+    $bcfg->policy( [ -DDEBUGGING => '-DDEBUGGING' ],
                    [ -DPERL_COPY_ON_WRITE => '' ] );
 
     if ( $bcfg->has_arg( '-Duseithreads' ) ) {
@@ -486,7 +486,7 @@ or
 
 =head1 DESCRIPTION
 
-This is a simple object that holds both the build arguments and the 
+This is a simple object that holds both the build arguments and the
 policy substitutions. The build arguments are stored as a string and
 the policy subtitutions are stored as a list of lists. Each substitution is
 represented as a list with the two elements: the target and its substitute.
@@ -540,7 +540,7 @@ sub policy {
     my $self = shift;
 
     if ( @_ ) {
-        my @substitutions = @_ == 1 &&  ref $_[0][0] eq 'ARRAY' 
+        my @substitutions = @_ == 1 &&  ref $_[0][0] eq 'ARRAY'
             ? @{ $_[0] } : @_;
         $self->[1] = \@substitutions;
     }
@@ -568,7 +568,7 @@ sub _split_args {
 
 =item $buildcfg->has_arg( $arg[,...] )
 
-Check the build arguments hash for C<$arg>. If you specify more then one 
+Check the build arguments hash for C<$arg>. If you specify more then one
 the results will be logically ANDed!
 
 =cut
@@ -583,7 +583,7 @@ sub has_arg {
 
 =item $buildcfg->any_arg( $arg[,...] )
 
-Check the build arguments hash for C<$arg>. If you specify more then one 
+Check the build arguments hash for C<$arg>. If you specify more then one
 the results will be logically ORed!
 
 =cut
@@ -610,8 +610,8 @@ sub args_eq {
     my $self = shift;
     my $args = shift;
 
-    my $default_args = join "|", sort { 
-        length($b) <=> length($a) 
+    my $default_args = join "|", sort {
+        length($b) <=> length($a)
     } quotewords( '\s+', 1, Test::Smoke::BuildCFG->config( 'dfopts' ) );
 
     my %copy = map { ( $_ => undef ) }

--- a/lib/Test/Smoke/FTPClient.pm
+++ b/lib/Test/Smoke/FTPClient.pm
@@ -49,7 +49,7 @@ Test::Smoke::FTPClient - Implement a mirror like object
 
 This module was written specifically to fetch a perl source-tree
 from the APC. It will not suffice as a general purpose mirror module!
-It only distinguishes between files and directories and relies on the 
+It only distinguishes between files and directories and relies on the
 output of the C<< Net::FTP->dir >> method.
 
 This solution is B<slow>, you'd better use B<rsync>!
@@ -119,7 +119,7 @@ sub connect {
 
     $self->{v} and print "Authenticating ";
     unless ( $self->{client}->login( $self->{fuser}, $self->{fpasswd} ) ) {
-        $self->{error} = $@ || 
+        $self->{error} = $@ ||
             "Could not login($self->{fuser}) on $self->{fserver}";
         $self->{v} and print "NOT OK ($self->{error})\n";
         return;
@@ -184,7 +184,7 @@ sub bye {
 
 =head2 Test::Smoke::FTPClient->config( $key[, $value] )
 
-C<config()> is an interface to the package lexical C<%CONFIG>, 
+C<config()> is an interface to the package lexical C<%CONFIG>,
 which holds all the default values for the C<new()> arguments.
 
 With the special key B<all_defaults> this returns a reference
@@ -232,7 +232,7 @@ sub __do_mirror {
 
     foreach my $entry ( sort { $a->{type} cmp $b->{type} ||
                                $a->{name} cmp $b->{name} } @list ) {
-        
+
         if ( $entry->{type} eq 'd' ) {
             $entry->{name} =~ m/^\.\.?$/ and next;
             my $new_locald = File::Spec->catdir( $localdir, $entry->{name} );
@@ -242,7 +242,7 @@ sub __do_mirror {
                 $@ and return;
             }
             chdir $new_locald;
-            $mirror_ok &&= __do_mirror( $ftp, $entry->{name}, 
+            $mirror_ok &&= __do_mirror( $ftp, $entry->{name},
                                         $new_locald, $lroot, $verbose,
                                         $cleanup, $totsize, $tottime );
             $entry->{time} ||= $entry->{date};
@@ -260,7 +260,7 @@ sub __do_mirror {
             if ( -e $destname ) {
                 my( $l_size, $l_mode, $l_time ) = (stat $destname)[7, 2, 9];
                 $l_mode &= 07777;
-                $skip = ($l_size == $entry->{size}) && 
+                $skip = ($l_size == $entry->{size}) &&
                         ($l_mode == $entry->{mode}) &&
 		        ($l_time == $entry->{time});
             }
@@ -286,7 +286,7 @@ sub __do_mirror {
                 chmod $entry->{mode}, $dest;
                 $verbose and printf "$size (%.${dig}f $sn[$ord]/s)\n",
                                      $speed;
-            } else { 
+            } else {
                 $verbose > 1 and
                     printf "%s: %d/skipped\n", abs2rel( $destname, $lroot),
                                                $entry->{size};
@@ -305,7 +305,7 @@ sub __do_mirror {
                 my $cmpname = clean_filename( $_ );
                 $^O eq 'VMS' and $cmpname =~ s/\.$//;
                 if( -f $cmpname ) {
-                    unless ( exists $ok_file{ $cmpname } && 
+                    unless ( exists $ok_file{ $cmpname } &&
                              $ok_file{ $cmpname } eq 'f' ) {
                         $verbose and printf "Delete %s\n",
                                              abs2rel( rel2abs( $cmpname ),
@@ -364,7 +364,7 @@ sub __parse_line_from_dir {
             type => $type,
             mode => __get_mode_from_text( substr $field[0], 1 ),
             size => $field[4],
-            time => 0, 
+            time => 0,
             date => __time_from_ls( @field[5, 6, 7] ),
         }
     } else { # Windowsy dir entry
@@ -407,7 +407,7 @@ and returns a localtime-stamp.
 
 =cut
 
-sub __time_from_ls { 
+sub __time_from_ls {
     my( $mname, $day, $time_or_year ) = @_;
 
     my( $local_year, $local_month) = (localtime)[5, 4];

--- a/lib/Test/Smoke/Mailer.pm
+++ b/lib/Test/Smoke/Mailer.pm
@@ -133,7 +133,7 @@ sub  new {
 
 =head2 Test::Smoke::Mailer->config( $key[, $value] )
 
-C<config()> is an interface to the package lexical C<%CONFIG>, 
+C<config()> is an interface to the package lexical C<%CONFIG>,
 which holds all the default values for the C<new()> arguments.
 
 With the special key B<all_defaults> this returns a reference

--- a/lib/Test/Smoke/Mailer/Base.pm
+++ b/lib/Test/Smoke/Mailer/Base.pm
@@ -86,7 +86,7 @@ sub _get_cc {
     my $p5p = $Test::Smoke::Mailer::P5P or return $self->{cc};
     my @cc = $self->{cc} ? $self->{cc} : ();
 
-    push @cc, $p5p unless $self->{to} =~ /\Q$p5p\E/ || 
+    push @cc, $p5p unless $self->{to} =~ /\Q$p5p\E/ ||
                           $self->{cc} =~ /\Q$p5p\E/;
     return join ", ", @cc;
 }

--- a/lib/Test/Smoke/Mailer/Mail_X.pm
+++ b/lib/Test/Smoke/Mailer/Mail_X.pm
@@ -24,7 +24,7 @@ Keys for C<%args>:
 
 =head2 $mailer->mail( )
 
-C<mail()> sets up the commandline and body and pipes it to either the 
+C<mail()> sets up the commandline and body and pipes it to either the
 B<mail> or the B<mailx> program.
 
 =cut
@@ -48,7 +48,7 @@ sub mail {
     local *MAILER;
     if ( open MAILER, "| $cmdline " ) {
         print MAILER $self->{body};
-        close MAILER or 
+        close MAILER or
             $self->{error} = "Error in pipe to '$mailer': $! (" . $?>>8 . ")";
     } else {
         $self->{error} = "Cannot fork '$mailer': $!";

--- a/lib/Test/Smoke/Mailer/SendEmail.pm
+++ b/lib/Test/Smoke/Mailer/SendEmail.pm
@@ -29,7 +29,7 @@ Keys for C<%args>:
 
 =head2 $mailer->mail( )
 
-C<mail()> sets up the commandline and body and passes it to the 
+C<mail()> sets up the commandline and body and passes it to the
 B<sendemail> program.
 
 =cut

--- a/lib/Test/Smoke/Mailer/Sendmail.pm
+++ b/lib/Test/Smoke/Mailer/Sendmail.pm
@@ -23,7 +23,7 @@ sub mail {
     my $subject   = $self->fetch_report();
     my $cc = $self->_get_cc( $subject );
     my $header = "To: $self->{to}\n";
-    $header   .= "From: $self->{from}\n" 
+    $header   .= "From: $self->{from}\n"
         if exists $self->{from} && $self->{from};
     $header   .= "Cc: $cc\n" if $cc;
     $header   .= "Bcc: $self->{bcc}\n" if $self->{bcc};

--- a/lib/Test/Smoke/Patcher.pm
+++ b/lib/Test/Smoke/Patcher.pm
@@ -69,7 +69,7 @@ There are two ways to initialise the B<Test::Smoke::Patcher> object.
 
 =item B<single> mode
 
-The B<pfile> attribute is a pointer to a I<single> patch. 
+The B<pfile> attribute is a pointer to a I<single> patch.
 There are four (4) ways to specify that patch.
 
 =over 4
@@ -89,7 +89,7 @@ You passed an opened filehandle to a file containing the patch.
 
 =item I<filename>
 
-If none of the above apply, it is assumed you passed a filename. 
+If none of the above apply, it is assumed you passed a filename.
 Relative paths are rooted at the builddir (B<ddir> attribute).
 
 =back
@@ -97,7 +97,7 @@ Relative paths are rooted at the builddir (B<ddir> attribute).
 =item B<multi> mode
 
 The B<pfile> attribute is a pointer to a recource that contains filenames
-of patches. 
+of patches.
 The format of this recource is one filename per line optionally followed
 by a semi-colon (;) and switches for the patch program.
 
@@ -121,7 +121,7 @@ The patch-resource can also be specified in four (4) ways.
 
 Constant: 1
 
-=head2 MAX_FLAG_COUNT 
+=head2 MAX_FLAG_COUNT
 
 Constant: 16
 
@@ -188,7 +188,7 @@ sub new {
 
 =item Test::Smoke::Patcher->config( $key[, $value] )
 
-C<config()> is an interface to the package lexical C<%CONFIG>, 
+C<config()> is an interface to the package lexical C<%CONFIG>,
 which holds all the default values for the C<new()> arguments.
 
 With the special key B<all_defaults> this returns a reference
@@ -284,9 +284,9 @@ sub perl_regen_headers {
 
 =item $patcher->patch_single( )
 
-C<patch_single()> checks if the B<pfile> attribute is a plain scalar 
+C<patch_single()> checks if the B<pfile> attribute is a plain scalar
 or a ref to a scalar, array, glob. In the first case this is taken to
-be a filename.  A GLOB-ref is a filehandle, the other two are taken to 
+be a filename.  A GLOB-ref is a filehandle, the other two are taken to
 be literal content.
 
 =cut
@@ -309,7 +309,7 @@ sub patch_single {
         $content = do { local $/; <PATCH> };
         $self->{pfinfo} ||= 'file content';
     } else {
-        my $full_name = File::Spec->file_name_is_absolute( $pfile ) 
+        my $full_name = File::Spec->file_name_is_absolute( $pfile )
             ? $pfile : File::Spec->rel2abs( $pfile, $self->{pdir} );
 
         $self->{pfinfo} = $full_name;
@@ -327,9 +327,9 @@ sub patch_single {
 
 =item $patcher->patch_multi( )
 
-C<patch_multi()> checks the B<pfile> attribute is a plain scalar 
+C<patch_multi()> checks the B<pfile> attribute is a plain scalar
 or a ref to a scalar, array, glob. In the first case this is taken to
-be a filename.  A GLOB-ref is a filehandle, the other two are taken to 
+be a filename.  A GLOB-ref is a filehandle, the other two are taken to
 be literal content.
 
 =cut
@@ -352,7 +352,7 @@ sub patch_multi {
         chomp( @patches = <PATCHES> );
         $self->{pfinfo} ||= 'file content';
     } else {
-        my $full_name = File::Spec->file_name_is_absolute( $pfile ) 
+        my $full_name = File::Spec->file_name_is_absolute( $pfile )
             ? $pfile : File::Spec->rel2abs( $pfile, $self->{pdir} );
         $self->{pfinfo} = $full_name;
         open PATCHES, "< $full_name" or do {
@@ -408,7 +408,7 @@ sub _make_opts {
 
 =item $patcher->call_patch( $ref_to_content )
 
-C<call_patch()> opens a pipe to the B<patch> program and prints 
+C<call_patch()> opens a pipe to the B<patch> program and prints
 C<< $$ref_to_content >> to it. It will Carp::croak() on any error!
 
 =cut
@@ -429,7 +429,7 @@ sub call_patch {
     };
 
     # patch is verbose enough if $self->{v} == 1
-    $self->{v} > 1 and 
+    $self->{v} > 1 and
         print "[$self->{pfinfo}] | $self->{patchbin} $opts $redir\n";
 
     if ( open PATCHBIN, "| $self->{patchbin} $opts $redir" ) {

--- a/lib/Test/Smoke/Policy.pm
+++ b/lib/Test/Smoke/Policy.pm
@@ -86,7 +86,7 @@ sub _do_subst {
     my $policy = $self->{_policy};
     while ( my( $target, $values ) = each %substs ) {
         unless ( $policy =~ s{^(\s*ccflags=.*?)$target}
-                             {$1 . join " ", 
+                             {$1 . join " ",
                                    grep $_ && length $_ => @$values}meg ) {
             require Carp;
             Carp::carp( "Policy target '$target' failed to match" );
@@ -163,7 +163,7 @@ sub _read_Policy {
         $vmsg = "anonymous filehandle";
 
     } else {
-        $srcpath = File::Spec->curdir 
+        $srcpath = File::Spec->curdir
             unless defined $srcpath && length $srcpath;
         my $p_name = File::Spec->catfile( $srcpath, 'Policy.sh' );
 

--- a/lib/Test/Smoke/Reporter.pm
+++ b/lib/Test/Smoke/Reporter.pm
@@ -98,7 +98,7 @@ sub new {
 
 [ Accessor | Public ]
 
-C<config()> is an interface to the package lexical C<%CONFIG>, 
+C<config()> is an interface to the package lexical C<%CONFIG>,
 which holds all the default values for the C<new()> arguments.
 
 With the special key B<all_defaults> this returns a reference
@@ -135,7 +135,7 @@ C<read_parse()> reads the smokeresults file and parses it.
 sub read_parse {
     my $self = shift;
 
-    my $result_file = @_ ? $_[0] : $self->{outfile} 
+    my $result_file = @_ ? $_[0] : $self->{outfile}
         ? catfile( $self->{ddir}, $self->{outfile} )
         : "";
     if ( $result_file ) {
@@ -195,7 +195,7 @@ sub _read {
         } else { # Allow intentional default_buildcfg()
             $self->{_outfile} = undef;
             $vmsg = "did fail";
-        } 
+        }
     }
     $self->{v} and print "Reading smokeresult $vmsg\n";
 }
@@ -376,7 +376,7 @@ sub _parse {
                             }
                         : # TEST output from minitest
                     $_info =~ m/^ (\w+) \s+at\ test\s+ (\d+) \s* $/x
-                 || $_info =~ m/^ (\w+)--(\S.*\S) \s* $/x 
+                 || $_info =~ m/^ (\w+)--(\S.*\S) \s* $/x
                         ? {
                             test   => $_test,
                             status => $1,
@@ -949,7 +949,7 @@ sub ccinfo {
     my $self = shift;
     my $cinfo = $self->{_rpt}{cinfo};
     unless ( $cinfo ) { # Old .out file?
-        my %Config = get_smoked_Config( $self->{ddir} => qw( 
+        my %Config = get_smoked_Config( $self->{ddir} => qw(
             cc ccversion gccversion
         ));
         $cinfo = "? ";
@@ -1100,7 +1100,7 @@ Returns the header of the report.
 sub preamble {
     my $self = shift;
 
-    my %Config = get_smoked_Config( $self->{ddir} => qw( 
+    my %Config = get_smoked_Config( $self->{ddir} => qw(
         version libc gnulibc_version
     ));
     my $si = Test::Smoke::SysInfo->new;
@@ -1156,7 +1156,7 @@ sub smoke_matrix {
     my $rptl = length $rpt->{patchdescr};
     my $pad = $rptl >= 11 ? "" : " " x int( (11 - $rptl)/2 );
     my $patch = $pad . $rpt->{patchdescr};
-    my $report = sprintf "%-11s  Configuration (common) %s\n", 
+    my $report = sprintf "%-11s  Configuration (common) %s\n",
                          $patch, $rpt->{common_args};
     $report .= ("-" x 11) . " " . ("-" x 57) . "\n";
 
@@ -1351,7 +1351,7 @@ sub signature {
     my $build_info = "$Test::Smoke::VERSION";
 
     my $signature = <<"    __EOS__";
--- 
+--
 Report by Test::Smoke v$build_info running on perl $this_pver
 (Reporter v$VERSION / Smoker v$Test::Smoke::Smoker::VERSION)
     __EOS__

--- a/lib/Test/Smoke/Smoker.pm
+++ b/lib/Test/Smoke/Smoker.pm
@@ -792,7 +792,7 @@ sub _run_harness3_target {
             push @failed, "    $extra\n";
             next;
         }
-    
+
         my( $parse_error ) = $line =~ /^  Parse errors: (.+)/;
         if ( $parse_error ) {
             push @failed, "${file}FAILED\n";

--- a/lib/Test/Smoke/SourceTree.pm
+++ b/lib/Test/Smoke/SourceTree.pm
@@ -82,7 +82,7 @@ sub new {
 
 =head2 $tree->canonpath( )
 
-C<canonpath()> returns the canonical name for the path, 
+C<canonpath()> returns the canonical name for the path,
 see L<File::Spec>.
 
 =cut
@@ -105,7 +105,7 @@ sub rel2abs {
 
 =head2 $tree->abs2rel( [$base_dir] )
 
-C<abs2rel()> returns  a relative path, 
+C<abs2rel()> returns  a relative path,
 see L<File::Spec>.
 
 =cut
@@ -117,7 +117,7 @@ sub abs2rel {
 
 =head2 $tree->mani2abs( $file[, $base_path] )
 
-C<mani2abs()> returns the absolute filename of C<$file>, which should 
+C<mani2abs()> returns the absolute filename of C<$file>, which should
 be in "MANIFEST" format (i.e. using '/' as directory separator).
 
 =cut
@@ -127,7 +127,7 @@ sub mani2abs {
 
     my $path = shift;
     my @dirs = split m{/+}, $path;
-    my $file = pop @dirs; 
+    my $file = pop @dirs;
     if ( $^O eq 'VMS' ) {
         my @parts = split m/\./, $file;
         my $last = pop @parts;
@@ -142,7 +142,7 @@ sub mani2abs {
 
 =head2 $tree->mani2absdir( $dir[, $base_path] )
 
-C<mani2abs()> returns the absolute dirname of C<$dir>, which should 
+C<mani2abs()> returns the absolute dirname of C<$dir>, which should
 be in "MANIFEST" format (i.e. using '/' as directory separator).
 
 =cut
@@ -176,7 +176,7 @@ sub abs2mani {
 C<check_MANIFEST()> reads the B<MANIFEST> file from C<< $$self >> and
 compares it with the actual contents of C<< $$self >>.
 
-Returns a hashref with suspicious entries (if any) as keys that have a 
+Returns a hashref with suspicious entries (if any) as keys that have a
 value of either B<ST_MISSING> (not in directory) or B<ST_UNDECLARED>
 (not in MANIFEST).
 
@@ -189,12 +189,12 @@ sub check_MANIFEST {
 
     my %ignore = map {
         my $entry = $NOCASE ? uc $_ : $_;
-        $entry => undef 
-    } ( ".patch", "MANIFEST.SKIP", '.git', '.gitignore', @_ ), 
+        $entry => undef
+    } ( ".patch", "MANIFEST.SKIP", '.git', '.gitignore', @_ ),
       keys %{ $self->_read_mani_file( 'MANIFEST.SKIP', 1 ) };
 
     # Walk the tree, remove all found files from %manifest
-    # and add other files to %manifest 
+    # and add other files to %manifest
     # unless they are in the ignore list
     my $cwd = cwd();
     chdir $$self or die "Cannot chdir($$self): $!";
@@ -222,7 +222,7 @@ sub check_MANIFEST {
     chdir $cwd;
 
     return \%manifest;
-} 
+}
 
 =head2 $self->_read_mani_file( $path[, $no_croak] )
 
@@ -243,7 +243,7 @@ sub _read_mani_file {
         croak( "Can't open '$manifile': $!" );
     };
 
-    my %manifest = map { 
+    my %manifest = map {
         m|(\S+)|;
         my $entry = $NOCASE ? uc $1 : $1;
         if ( $^O eq 'VMS' ) {
@@ -275,7 +275,7 @@ sub clean_from_MANIFEST {
 
     my $mani_check = $self->check_MANIFEST( @_ );
     my @to_remove = grep {
-        $mani_check->{ $_ } == ST_UNDECLARED 
+        $mani_check->{ $_ } == ST_UNDECLARED
     } keys %$mani_check;
 
     foreach my $entry ( @to_remove ) {

--- a/lib/Test/Smoke/Syncer.pm
+++ b/lib/Test/Smoke/Syncer.pm
@@ -155,35 +155,35 @@ At this moment we support three basic types of syncing the perl source-tree.
 
 =item rsync
 
-This method uses the B<rsync> program with the C<< --delete >> option 
+This method uses the B<rsync> program with the C<< --delete >> option
 to get your perl source-tree up to date.
 
 =item snapshot
 
-This method uses the B<Net::FTP> or the B<LWP> module to get the 
+This method uses the B<Net::FTP> or the B<LWP> module to get the
 latest snapshot. When the B<server> attribute starts with I<http://>
 the fetching is done by C<LWP::Simple::mirror()>.
 To emulate the C<< rsync --delete >> effect, the current source-tree
 is removed.
 
-The snapshot tarball is handled by either B<tar>/B<gzip> or 
+The snapshot tarball is handled by either B<tar>/B<gzip> or
 B<Archive::Tar>/B<Compress::Zlib>.
 
 =item copy
 
 This method uses the B<File::Copy> module to copy an existing source-tree
-from somewhere on the system (in case rsync doesn't work), this also 
+from somewhere on the system (in case rsync doesn't work), this also
 removes the current source-tree first.
 
 =item forest
 
 This method will sync the source-tree in one of the above basic methods.
-After that, it will create an intermediate copy of the master directory 
+After that, it will create an intermediate copy of the master directory
 as hardlinks and run the F<regen_headers.pl> script. This should yield
-an up-to-date source-tree. The intermadite directory is now copied as 
+an up-to-date source-tree. The intermadite directory is now copied as
 hardlinks to its final directory ({ddir}).
 
-This can be used to change the way B<make distclean> is run from 
+This can be used to change the way B<make distclean> is run from
 F<mktest.pl> (removes all files that are not in the intermediate
 directory, which may prove faster than traditional B<make distclean>).
 
@@ -244,7 +244,7 @@ sub new {
 
 [ Accessor | Public ]
 
-C<config()> is an interface to the package lexical C<%CONFIG>, 
+C<config()> is an interface to the package lexical C<%CONFIG>,
 which holds all the default values for the C<new()> arguments.
 
 With the special key B<all_defaults> this returns a reference

--- a/lib/Test/Smoke/Syncer/Base.pm
+++ b/lib/Test/Smoke/Syncer/Base.pm
@@ -39,7 +39,7 @@ sub sync {
 
 [ Method | private-ish ]
 
-C<_clear_source_tree()> removes B<all> files in the source-tree 
+C<_clear_source_tree()> removes B<all> files in the source-tree
 using B<File::Path::rmtree()>. (See L<File::Path> for caveats.)
 
 If C<$tree_dir> is not specified, C<< $self->{ddir} >> is used.
@@ -63,7 +63,7 @@ sub _clear_source_tree {
 
 [ Method | Private-ish ]
 
-C<_relocate_tree()> uses B<File::Copy::move()> to move the source-tree 
+C<_relocate_tree()> uses B<File::Copy::move()> to move the source-tree
 from C<< $source_dir >> to its destination (C<< $self->{ddir} >>).
 
 =cut
@@ -173,7 +173,7 @@ sub check_dot_patch {
 
 =head2 version_from_patchlevel_h( $ddir )
 
-C<version_from_patchlevel_h()> returns a "dotted" version as derived 
+C<version_from_patchlevel_h()> returns a "dotted" version as derived
 from the F<patchlevel.h> file in the distribution.
 
 =cut

--- a/lib/Test/Smoke/Syncer/Copy.pm
+++ b/lib/Test/Smoke/Syncer/Copy.pm
@@ -6,9 +6,9 @@ use base 'Test::Smoke::Syncer::Base';
 
 =head1 Test::Smoke::Syncer::Copy
 
-This handles syncing with the B<File::Copy> module from a local 
+This handles syncing with the B<File::Copy> module from a local
 directory. It uses the B<MANIFEST> file is the source directory
-to determine which fiels to copy. The current source-tree removed 
+to determine which fiels to copy. The current source-tree removed
 before the actual copying.
 
 =cut

--- a/lib/Test/Smoke/Syncer/FTP.pm
+++ b/lib/Test/Smoke/Syncer/FTP.pm
@@ -35,7 +35,7 @@ Known args for this class:
 This does the actual syncing:
 
     * Check {ftpcdir} for the latest changenumber
-    * Mirror 
+    * Mirror
 
 =cut
 

--- a/lib/Test/Smoke/Syncer/Rsync.pm
+++ b/lib/Test/Smoke/Syncer/Rsync.pm
@@ -6,8 +6,8 @@ use base 'Test::Smoke::Syncer::Base';
 
 =head1 Test::Smoke::Syncer::Rsync
 
-This handles syncing with the B<rsync> program. 
-It should only be visible from the "parent-package" so no direct 
+This handles syncing with the B<rsync> program.
+It should only be visible from the "parent-package" so no direct
 user-calls on this.
 
 =cut
@@ -30,7 +30,7 @@ This crates the new object. Keys for C<%args>:
 
 Do the actual sync using a call to the B<rsync> program.
 
-B<rsync> can also be used as a smart version of copy. If you 
+B<rsync> can also be used as a smart version of copy. If you
 use a local directory to rsync from, make sure the destination path
 ends with a I<path separator>! (This does not seem to work for source
 paths mounted via NFS.)

--- a/lib/Test/Smoke/Syncer/Snapshot.pm
+++ b/lib/Test/Smoke/Syncer/Snapshot.pm
@@ -6,8 +6,8 @@ use base 'Test::Smoke::Syncer::Base';
 
 =head1 Test::Smoke::Syncer::Snapshot
 
-This handles syncing from a snapshot with the B<Net::FTP> module. 
-It should only be visible from the "parent-package" so no direct 
+This handles syncing from a snapshot with the B<Net::FTP> module.
+It should only be visible from the "parent-package" so no direct
 user-calls on this.
 
 =cut
@@ -32,7 +32,7 @@ This crates the new object. Keys for C<%args>:
 =head2 $syncer->sync( )
 
 Make a connection to the ftp server, change to the {sdir} directory.
-Get the list of snapshots (C<< /^perl@\d+\.tgz$/ >>) and determin the 
+Get the list of snapshots (C<< /^perl@\d+\.tgz$/ >>) and determin the
 highest patchlevel. Fetch this file.  Remove the current source-tree
 and extract the snapshot.
 
@@ -60,7 +60,7 @@ sub sync {
 
 =head2 $syncer->_fetch_snapshot( )
 
-C<_fetch_snapshot()> checks to see if 
+C<_fetch_snapshot()> checks to see if
 C<< S<< $self->{server} =~ m|^https?://| >> && $self->{sfile} >>.
 If so let B<LWP::Simple> do the fetching else do the FTP thing.
 
@@ -116,7 +116,7 @@ sub _fetch_snapshot {
                              "$snap_name\n as $local_snap ";
         my $l_file = $ftp->get( $snap_name, $local_snap );
         my $ok = $l_file eq $local_snap && $snap_size == -s $local_snap;
-        $ok or printf "Error in get(%s) [%d]\n", $l_file || "", 
+        $ok or printf "Error in get(%s) [%d]\n", $l_file || "",
                                                  (-s $local_snap);
         $ok && $self->{v} and print "[$snap_size] OK\n";
     }
@@ -189,7 +189,7 @@ sub __find_snap_name {
         [ $_, $p_level ]
     } grep {
     	/^perl[@#_]\d+/ &&
-    	/$snapext$/ 
+    	/$snapext$/
     } map { $verbose > 1 and print "Found snapname: $_\n"; $_ } @list )[-1];
 
     return $snap_name;
@@ -197,8 +197,8 @@ sub __find_snap_name {
 
 =head2 $syncer->_extract_snapshot( )
 
-C<_extract_snapshot()> checks the B<tar> attribute to find out how to 
-extract the snapshot. This could be an external command or the 
+C<_extract_snapshot()> checks the B<tar> attribute to find out how to
+extract the snapshot. This could be an external command or the
 B<Archive::Tar>/B<Comperss::Zlib> modules.
 
 =cut
@@ -252,7 +252,7 @@ sub _extract_snapshot {
 =head2 $syncer->_extract_with_Archive_Tar( )
 
 C<_extract_with_Archive_Tar()> uses the B<Archive::Tar> and
-B<Compress::Zlib> modules to extract the snapshot. 
+B<Compress::Zlib> modules to extract the snapshot.
 (This tested verry slow on my Linux box!)
 
 =cut
@@ -287,7 +287,7 @@ sub _extract_with_Archive_Tar {
 
 =head2 $syncer->_extract_with_external( )
 
-C<_extract_with_external()> uses C<< $self->{tar} >> as a sprintf() 
+C<_extract_with_external()> uses C<< $self->{tar} >> as a sprintf()
 template to build a command. Yes that might be dangerous!
 
 =cut
@@ -363,7 +363,7 @@ EO_UNTGZ
 =head2 $syncer->patch_a_snapshot( $patch_number )
 
 C<patch_a_snapshot()> tries to fetch all the patches between
-C<$patch_number> and C<perl-current> and apply them. 
+C<$patch_number> and C<perl-current> and apply them.
 This requires a working B<patch> program.
 
 You should pass this extra information to
@@ -392,8 +392,8 @@ sub patch_a_snapshot {
 
 =head2 $syncer->_get_patches( [$patch_number] )
 
-C<_get_patches()> sets up the FTP connection and gets all patches 
-beyond C<$patch_number>. Remember that patch numbers  do not have to be 
+C<_get_patches()> sets up the FTP connection and gets all patches
+beyond C<$patch_number>. Remember that patch numbers  do not have to be
 consecutive.
 
 =cut
@@ -460,7 +460,7 @@ and updates B<.patch> accordingly.
 
 C<@patch_list> is a list of filenames of these patches.
 
-Checks the B<unzip> attribute to find out how to unzip the patch and 
+Checks the B<unzip> attribute to find out how to unzip the patch and
 uses the B<Test::Smoke::Patcher> module to apply the patch.
 
 =cut
@@ -526,7 +526,7 @@ sub _read_patch {
 
         my $buffer;
         $content .= $buffer while $unzip->gzread( $buffer ) > 0;
- 
+
         unless ( $Compress::Zlib::gzerrno == Compress::Zlib::Z_STREAM_END() ) {
             require Carp;
             Carp::carp( "Error reading '$file': $Compress::Zlib::gzerrno" );
@@ -553,7 +553,7 @@ C<_fix_dot_patch()> updates the B<.patch> file with the new patch level.
 sub _fix_dot_patch {
     my( $self, $new_level ) = @_;
 
-    return $self->check_dot_patch 
+    return $self->check_dot_patch
         unless defined $new_level && $new_level =~ /^\d+$/;
 
     my $dot_patch = File::Spec->catfile( $self->{ddir}, '.patch' );
@@ -571,8 +571,8 @@ sub _fix_dot_patch {
 
 [This is B<not> a method]
 
-C<__get_directory_names()> retruns all directory names from 
-C<< $dir || cwd() >>. It does not look at symlinks (there should 
+C<__get_directory_names()> retruns all directory names from
+C<< $dir || cwd() >>. It does not look at symlinks (there should
 not be any in the perl source-tree).
 
 =cut

--- a/lib/Test/Smoke/SysInfo/BSD.pm
+++ b/lib/Test/Smoke/SysInfo/BSD.pm
@@ -46,7 +46,7 @@ sub __get_sysctl {
     my %extra = ( cpufrequency => undef, cpuspeed => undef );
     my @e_args = map {
         /^hw\.(\w+)\s*[:=]/; $1
-    } grep /^hw\.(\w+)/ && exists $extra{ $1 } => `$sysctl_cmd -a hw`; 
+    } grep /^hw\.(\w+)/ && exists $extra{ $1 } => `$sysctl_cmd -a hw`;
 
     foreach my $name ( qw( model machine ncpu ), @e_args ) {
         chomp( $sysctl{ $name } = `$sysctl_cmd hw.$name` );

--- a/lib/Test/Smoke/SysInfo/Darwin.pm
+++ b/lib/Test/Smoke/SysInfo/Darwin.pm
@@ -71,7 +71,7 @@ sub __get_system_profiler {
     }
 
     $system_profiler{'CPU Type'} =~ s/PowerPC\s*(\w+).*/macppc$1/;
-    $system_profiler{'CPU Speed'} =~ 
+    $system_profiler{'CPU Speed'} =~
         s/(0(?:\.\d+)?)\s*GHz/sprintf("%d MHz", $1 * 1000)/e;
 
     return \%system_profiler;

--- a/lib/Test/Smoke/SysInfo/HPUX.pm
+++ b/lib/Test/Smoke/SysInfo/HPUX.pm
@@ -83,7 +83,7 @@ sub _prepare_cpu_type {
         if (@cpu and $cpu[0] =~ m/^\S+\s+(\d+\.\d+[a-z]?)\s+(\S+)/) {
              my( $arch, $cpu ) = ( "PA-RISC$1", $2 );
              $self->{__cpu} = $cpu;
-             chomp( my $hw3264 = 
+             chomp( my $hw3264 =
                     `/usr/bin/getconf HW_32_64_CAPABLE 2>/dev/null` );
             (my $osvers = $self->{__os}) =~ s/.*[AB]\.//;
             $osvers =~ s{/.*}{};

--- a/lib/Test/Smoke/SysInfo/Linux.pm
+++ b/lib/Test/Smoke/SysInfo/Linux.pm
@@ -274,7 +274,7 @@ sub linux_ppc {
         $info{detected} =~ s/.*(\b.+Mac G\d).*/$1/;
         $info{machine} = $info{detected};
     }
-        
+
     $self->{__cpu} = sprintf "%s %s (%s)", map $info{ $_ } => @parts;
 }
 

--- a/lib/Test/Smoke/Util.pm
+++ b/lib/Test/Smoke/Util.pm
@@ -6,7 +6,7 @@ use vars qw( $VERSION @EXPORT @EXPORT_OK $NOCASE );
 $VERSION = '0.58';
 
 use base 'Exporter';
-@EXPORT = qw( 
+@EXPORT = qw(
     &Configure_win32
     &get_cfg_filename &get_config
     &get_patch
@@ -15,7 +15,7 @@ use base 'Exporter';
 
 @EXPORT_OK = qw(
     &grepccmsg &grepnonfatal &get_local_patches &set_local_patch
-    &get_ncpu &get_smoked_Config &parse_report_Config 
+    &get_ncpu &get_smoked_Config &parse_report_Config
     &get_regen_headers &run_regen_headers
     &whereis &clean_filename &read_logfile
     &calc_timeout &time_in_hhmm
@@ -46,7 +46,7 @@ C<Configure_win32()> alters the settings of the makefile for MSWin32.
 
 C<$command> is in the form of './Configure -des -Dusedevel ...'
 
-C<$win32_maker> should either be C<nmake> or C<dmake>, the default 
+C<$win32_maker> should either be C<nmake> or C<dmake>, the default
 is C<nmake>.
 
 C<@args> is a list of C<< option=value >> pairs that will (eventually)
@@ -104,21 +104,21 @@ sets INST_DRV to a new value (default is "c:")
 
 =item * B<-DINST_TOP=...>
 
-sets INST_DRV to a new value (default is "$(INST_DRV)\perl"), this is 
+sets INST_DRV to a new value (default is "$(INST_DRV)\perl"), this is
 where perl will be installed when C<< [nd]make install >> is run.
 
 =item * B<-DINST_VER=...>
 
 sets INST_VER to a new value (default is forced not set), this is also used
 as part of the installation path to get a more unixy installation.
-Without C<INST_VER> and C<INST_ARCH> you get an ActiveState like 
+Without C<INST_VER> and C<INST_ARCH> you get an ActiveState like
 installation.
 
 =item * B<-DINST_ARCH=...>
 
 sets INST_ARCH to a new value (default is forced not set), this is also used
 as part of the installation path to get a more unixy  installation.
-Without C<INST_VER> and C<INST_ARCH> you get an ActiveState like 
+Without C<INST_VER> and C<INST_ARCH> you get an ActiveState like
 installation.
 
 =item * B<-DCCHOME=...>
@@ -144,7 +144,7 @@ Set the cf_email option (Config.pm)
 
 =item * B<-Accflags=...>
 
-Adds the option to BUILDOPT. This is implemented differently for 
+Adds the option to BUILDOPT. This is implemented differently for
 B<nmake> and B<dmake>.
 Returns the name of the outputfile.
 
@@ -454,12 +454,12 @@ sub grepccmsg {
         'irix' =>
             # cc-pppp cc: WARNING File = foo.c, Line = nnnn
             # ...error description...
-            # 
+            #
             # ...error line...
             #   ^
             # cc-pppp cc: ERROR File = foo.c, Line = nnnn
             # ...error description...
-            # 
+            #
             # ...error line...
             #   ^
             '^(cc-\d+ cc: (?:WARNING|ERROR) File = .+?, ' .
@@ -735,7 +735,7 @@ sub get_config {
         }
 
         while (my ($key, $val) = each %conf) {
-            $val > 1 and 
+            $val > 1 and
                 warn "Configuration line '$key' duplicated $val times";
         }
         my $args = [@conf];
@@ -802,7 +802,7 @@ sub get_patch {
 
 =head2 version_from_patchlevel_h( $ddir )
 
-C<version_from_patchlevel_h()> returns a "dotted" version as derived 
+C<version_from_patchlevel_h()> returns a "dotted" version as derived
 from the F<patchlevel.h> file in the distribution.
 
 =cut
@@ -835,7 +835,7 @@ sub version_from_patchlevel_h {
     }
     return "$revision.$version.$subversion";
 }
- 
+
 =head2 get_ncpu( $osname )
 
 C<get_ncpu()> returns the number of available (online/active/enabled) CPUs.
@@ -844,7 +844,7 @@ It does this by using some operating system specific trick (usually
 by running some external command and parsing the output).
 
 If it cannot recognize your operating system an empty string is returned.
-If it can recognize it but the external command failed, C<"? cpus"> 
+If it can recognize it but the external command failed, C<"? cpus">
 is returned.
 
 In the first case (where we really have no idea how to proceed),
@@ -915,7 +915,7 @@ sub get_ncpu {
         };
 
         /mswin32|cygwin/i && do {
-            $cpus = exists $ENV{NUMBER_OF_PROCESSORS} 
+            $cpus = exists $ENV{NUMBER_OF_PROCESSORS}
                 ? $ENV{NUMBER_OF_PROCESSORS} : '';
             last OS_CHECK;
         };
@@ -948,7 +948,7 @@ sub get_ncpu {
 C<get_smoked_Config()> returns a hash (a listified hash) with the
 specified keys. It will try to find F<lib/Config.pm> to get those
 values, if that cannot be found (make error?) we can try F<config.sh>
-which is used to build F<lib/Config.pm>. 
+which is used to build F<lib/Config.pm>.
 If F<config.sh> is not there (./Configure error?) we try to get some
 fallback information from C<POSIX::uname()> and F<patchlevel.h>.
 
@@ -1008,7 +1008,7 @@ sub get_smoked_Config {
     %conf2 = map {
         ( $_ => undef )
     } grep !defined $Config{ $_ } => keys %Config;
-    if ( keys %conf2 ) { 
+    if ( keys %conf2 ) {
         # Fall-back values from POSIX::uname() (not reliable)
         require POSIX;
         my( $osname, undef, $osvers, undef, $arch) = POSIX::uname();
@@ -1028,7 +1028,7 @@ sub get_smoked_Config {
 
 C<parse_report_Config()> returns a list attributes from a smoke report.
 
-    my( $version, $plevel, $os, $osvers, $archname, $summary, $branch ) = 
+    my( $version, $plevel, $os, $osvers, $archname, $summary, $branch ) =
         parse_report_Config( $rpt );
 
 =cut
@@ -1054,7 +1054,7 @@ sub parse_report_Config {
 
 =head2 get_regen_headers( $ddir )
 
-C<get_regen_headers()> looks in C<$ddir> to find either 
+C<get_regen_headers()> looks in C<$ddir> to find either
 F<regen_headers.pl> or F<regen.pl> (change 18851).
 
 Returns undef if not found or a string like C<< $^X "$regen_headers_pl" >>
@@ -1204,7 +1204,7 @@ sub clean_filename {
 
 =head2 calc_timeout( $killtime[, $from] )
 
-C<calc_timeout()> calculates the timeout in seconds. 
+C<calc_timeout()> calculates the timeout in seconds.
 C<$killtime> can be one of two formats:
 
 =over 8
@@ -1300,7 +1300,7 @@ EO_MSG
     }
 }
 
-=head2 skip_config( $config ) 
+=head2 skip_config( $config )
 
 Returns true if this config should be skipped.
 C<$config> should be a B<Test::Smoke::BuildCFG::Config> object.
@@ -1312,7 +1312,7 @@ sub skip_config {
 
     my $skip = $config->has_arg(qw( -Uuseperlio -Dusethreads )) ||
                $config->has_arg(qw( -Uuseperlio -Duseithreads )) ||
-               ( $^O eq 'MSWin32' && 
+               ( $^O eq 'MSWin32' &&
                (( $config->has_arg(qw( -Duseithreads -Dusemymalloc )) &&
                 !$config->has_arg( '-Uuseimpsys' ) ) ||
                ( $config->has_arg(qw( -Dusethreads -Dusemymalloc )) &&

--- a/mailrpt.pl
+++ b/mailrpt.pl
@@ -154,7 +154,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }
@@ -192,7 +192,7 @@ sub check_for_report {
     my $reporter = Test::Smoke::Reporter->new( $conf );
     if ( defined $reporter->{_outfile} ) {
         $reporter->write_to_file;
-    
+
         unless ( -f $report ) {
             die "Hmmm... cannot find [$report]";
         }

--- a/patchtree.pl
+++ b/patchtree.pl
@@ -102,7 +102,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }

--- a/resmoke.pl
+++ b/resmoke.pl
@@ -61,7 +61,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }
@@ -92,7 +92,7 @@ my $cwd = cwd();
     my $smoker   = Test::Smoke::Smoker->new( \*LOG, $conf );
 
     for my $bcfg ( $BuildCFG->configurations ) {
-        $smoker->ttylog( join "\n", 
+        $smoker->ttylog( join "\n",
                               "", "Configuration: $bcfg", "-" x 78, "" );
         $smoker->smoke( $bcfg, $Policy );
     }

--- a/runsmoke.pl
+++ b/runsmoke.pl
@@ -46,8 +46,8 @@ runsmoke.pl - Configure, build and test bleading edge perl
 
 =head1 OPTIONS
 
-Most of the F<mktest.pl> switches are implemented for backward 
-compatibility, but some had to go in faviour of the new regime of 
+Most of the F<mktest.pl> switches are implemented for backward
+compatibility, but some had to go in faviour of the new regime of
 front-ends.
 
 =over 4
@@ -57,13 +57,13 @@ front-ends.
     --config|-c <configfile>  Use the settings from the configfile
 
 F<runsmoke.pl> can use the configuration file created by
-F<configsmoke.pl>.  Other options can override the settings 
-from the configuration file. If the config-filename is ommited 
+F<configsmoke.pl>.  Other options can override the settings
+from the configuration file. If the config-filename is ommited
 B<smokecurrent_config> is assumed.
 
 =item Overridable options
 
-These options will also override the values in the configfile 
+These options will also override the values in the configfile
 (if the C<--config> switch is used).
 
     --fdir|--forest|-f <dir>  Set the basedir for forest
@@ -95,7 +95,7 @@ These options will also override the values in the configfile
 
 =head1 DESCRIPTION
 
-F<runsmoke.pl> is the replacement script for F<mktest.pl> (which is now 
+F<runsmoke.pl> is the replacement script for F<mktest.pl> (which is now
 depricated and will not be maintained).
 
 =cut
@@ -140,7 +140,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }

--- a/sendrpt.pl
+++ b/sendrpt.pl
@@ -143,7 +143,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }
@@ -187,7 +187,7 @@ sub check_for_report {
     my $reporter = Test::Smoke::Reporter->new( $conf );
     if ( defined $reporter->{_outfile} ) {
         $reporter->write_to_file;
-    
+
         if (!-f $report) {
             die "Hmmm... cannot find [$report]";
         }

--- a/smokeperl.pl
+++ b/smokeperl.pl
@@ -55,9 +55,9 @@ my %options = (
 );
 
 my $myusage = "Usage: $0 [-c configname]";
-GetOptions( \%options, 
-    'config|c=s', 
-    'fetch!', 
+GetOptions( \%options,
+    'config|c=s',
+    'fetch!',
     'patch!',
     'ccp5p_onfail!',
     'mail!',
@@ -79,9 +79,9 @@ GetOptions( \%options,
     'help|h', 'man',
 ) or do_pod2usage(  verbose => 1, myusage => $myusage );
 
-$options{ man} 
+$options{ man}
     and do_pod2usage( verbose => 2, exitval => 0, myusage => $myusage );
-$options{help} 
+$options{help}
     and do_pod2usage( verbose => 1, exitval => 0, myusage => $myusage );
 
 =head1 NAME
@@ -134,7 +134,7 @@ unless ( read_config( $config_file ) ) {
     $config_file = catfile( $findbin, $options{config} );
     read_config( $config_file );
 }
-defined Test::Smoke->config_error and 
+defined Test::Smoke->config_error and
     die "!!!Please run 'configsmoke.pl'!!!\nCannot find configuration: $!";
 
 # smartsmoke doesn't make sense with nofetch (unless you say so)
@@ -190,7 +190,7 @@ sub synctree {
         # and make distclean will not see leftovers
         if ( $options{snapshot} ) {
             if ( $conf->{sync_type} eq 'snapshot' ||
-               ( $conf->{sync_type} eq 'forest'   && 
+               ( $conf->{sync_type} eq 'forest'   &&
                  $conf->{fsync} eq 'snapshot' ) ) {
 
                 $conf->{sfile} = snapshot_name();
@@ -201,12 +201,12 @@ sub synctree {
         }
         my $syncer = Test::Smoke::Syncer->new( $conf->{sync_type}, $conf );
         $now_patchlevel = $syncer->sync;
-        $conf->{v} and 
+        $conf->{v} and
             print "$conf->{ddir} now up to patchlevel $now_patchlevel\n";
     }
 
     if ( $conf->{smartsmoke} && ($was_patchlevel eq $now_patchlevel) ) {
-        $conf->{v} and 
+        $conf->{v} and
             print "Skipping this smoke, patchlevel ($was_patchlevel)" .
                   " did not change.\n";
         exit(0);
@@ -221,8 +221,8 @@ sub patchtree {
                 print "Skipping patching ($conf->{pfile})\n";
             last PATCHAPERL;
         }
-        last PATCHAPERL unless exists $conf->{patch_type} && 
-                               $conf->{patch_type} eq 'multi' && 
+        last PATCHAPERL unless exists $conf->{patch_type} &&
+                               $conf->{patch_type} eq 'multi' &&
                                $conf->{pfile};
         my $patcher = Test::Smoke::Patcher->new( $conf->{patch_type}, $conf );
         eval { $patcher->patch };
@@ -298,7 +298,7 @@ sub archiverpt {
     return unless exists $conf->{adir};
     return if $conf->{adir} eq "";
     -d $conf->{adir} or do {
-        mkpath( $conf->{adir}, 0, 0775 ) or 
+        mkpath( $conf->{adir}, 0, 0775 ) or
             die "Cannot create '$conf->{adir}': $!";
     };
 
@@ -330,7 +330,7 @@ sub archiverpt {
     SKIP_LOG: {
         my $archived_log = "log${patch_level}.log";
         last SKIP_LOG unless defined $conf->{lfile};
-        last SKIP_LOG 
+        last SKIP_LOG
             unless -f $conf->{lfile};
         copy( $conf->{lfile},
               catfile( $conf->{adir}, $archived_log ) ) or

--- a/smokestatus.pl
+++ b/smokestatus.pl
@@ -16,7 +16,7 @@ use lib catdir( $FindBin::Bin, 'lib' );
 use lib $FindBin::Bin;
 use Test::Smoke;
 use Test::Smoke::Reporter;
-use Test::Smoke::Util qw( 
+use Test::Smoke::Util qw(
     do_pod2usage time_in_hhmm calc_timeout
     get_patch parse_report_Config );
 
@@ -94,7 +94,7 @@ $opt{dir} && -d $opt{dir} or $opt{dir} = '';
 $opt{dir} ||= $FindBin::Bin;
 
 my %save_opt = %opt;
-my @configs = $opt{all} 
+my @configs = $opt{all}
     ? get_configs() : $opt{running} ? get_lcks() : $opt{config};
 
 print "$0-$VERSION Test::Smoke-$Test::Smoke::VERSION Test::Smoke::Reporter-$Test::Smoke::Reporter::VERSION\n\n";
@@ -114,7 +114,7 @@ foreach my $config ( @configs ) {
     my $ccnt = 0;
     Test::Smoke::skip_config( $_ ) or $ccnt++ for $bcfg->configurations;
 
-    printf "  Change number $rpt->{patch} started on %s.\n", 
+    printf "  Change number $rpt->{patch} started on %s.\n",
            scalar localtime( $rpt->{started} );
 
     print "    $rpt->{ccount} out of $ccnt configurations finished",
@@ -137,9 +137,9 @@ foreach my $config ( @configs ) {
     my $killtime = calc_timeout( $conf->{killtime}, $rpt->{started} )
         ? timeout_msg( $conf->{killtime}, $rpt->{started } )
         : "";
-    
-    my $todo_time = $rpt->{avg} <= 0  ? '.' : 
-        $est_todo <= 0 
+
+    my $todo_time = $rpt->{avg} <= 0  ? '.' :
+        $est_todo <= 0
             ? has_lck( $config )
                 ? ", smoke looks hanging delay " . time_in_hhmm( -$est_todo )
                 : ", smoke looks terminated${killtime}."
@@ -154,9 +154,9 @@ foreach my $config ( @configs ) {
 
     if ( $rpt->{ccount} > 0 && $opt{matrix} ) {
         printf "  Matrix, using %s:\n", $rpt->{reporter}->ccinfo;
-        print join "", map "  $_\n" 
+        print join "", map "  $_\n"
             => split /\n/, $rpt->{reporter}->smoke_matrix;
-        print join "", map "  $_\n" 
+        print join "", map "  $_\n"
             => split /\n/, $rpt->{reporter}->bldenv_legend;
     }
 }
@@ -176,7 +176,7 @@ sub guess_status {
                 my $summary = ( parse_report_Config( $report ) )[-1];
                 $status = $summary ? " [$summary]" : "";
             }
-            printf "  Change number %s%s finshed on %s\n", 
+            printf "  Change number %s%s finshed on %s\n",
                    $patch, $status, scalar localtime( $mtime );
         } else {
             print "  Change number $patch found, but no (previous) results.\n";
@@ -206,7 +206,7 @@ sub parse_out {
 
         if ( $rpt{statcfg}{ $config } ) {
             $fcnt = $rpt{statcfg}{ $config };
-            $rpt{statcfg}{ $config } = "F" 
+            $rpt{statcfg}{ $config } = "F"
                 if $rpt{statcfg}{ $config } =~ /^\d+$/;
 
             $rpt{fail}++;
@@ -216,7 +216,7 @@ sub parse_out {
     $rpt{stat} = join "", sort keys %{ $rpt{stat} };
 
     $rpt{reporter} = $reporter;
-    return \%rpt    
+    return \%rpt
 }
 
 sub get_configs {
@@ -251,12 +251,12 @@ sub process_args {
 
     unless ( Test::Smoke->config_error ) {
         foreach my $option ( keys %$conf ) {
-            $opt{ $option } = $conf->{ $option }, next 
+            $opt{ $option } = $conf->{ $option }, next
               unless defined $opt{ $option };
             $conf->{ $option } = $opt{ $option }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }

--- a/sprove.pl
+++ b/sprove.pl
@@ -52,7 +52,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }

--- a/synctree.pl
+++ b/synctree.pl
@@ -151,7 +151,7 @@ if ( defined $opt{config} ) {
             }
         }
     } else {
-        warn "WARNING: Could not process '$opt{config}': " . 
+        warn "WARNING: Could not process '$opt{config}': " .
              Test::Smoke->config_error . "\n";
     }
 }

--- a/t/TestLib.pm
+++ b/t/TestLib.pm
@@ -8,7 +8,7 @@ $VERSION = '0.06';
 use Test::Smoke::Util qw( whereis );
 
 use base 'Exporter';
-@EXPORT = qw( 
+@EXPORT = qw(
     &whereis
     &find_a_patch
     &find_unzip &do_unzip
@@ -189,7 +189,7 @@ sub find_unzip {
 Returns the gunzipped contents of C<$uzfile>.
 
 =cut
-        
+
 sub do_unzip {
     my( $unzip, $uzfile ) = @_;
     return undef unless -f $uzfile;

--- a/t/app/030-app-base.t
+++ b/t/app/030-app-base.t
@@ -158,7 +158,7 @@ use Test::Smoke::App::AppOption;
         };
         local *STDOUT;
         open STDOUT, '>', \$helptxt;
-        
+
         local @ARGV = ('--help', '--test1', 'app');
         $app = Test::Smoke::App::Test1->new(
             main_options => [

--- a/t/buildcfg.t
+++ b/t/buildcfg.t
@@ -71,11 +71,11 @@ __EOCFG__
     foreach my $config ( $bcfg->configurations ) {
         if ( ($config->policy)[0]->[1] ) {
             ok( $config->has_arg( '-DDEBUGGING' ), "has_arg(-DDEBUGGING)" );
-            like( "$config", '/-DDEBUGGING/', 
+            like( "$config", '/-DDEBUGGING/',
                   "'$config' has -DDEBUGGING" );
         } else {
             ok( !$config->has_arg( '-DDEBUGGING' ), "! has_arg(-DDEBUGGING)" );
-            unlike( "$config", '/-DDEBUGGING/', 
+            unlike( "$config", '/-DDEBUGGING/',
                     "'$config' has no -DDEBUGGING" );
         }
         ok( $config->args_eq( "$config" ), "Stringyfied: args_eq($config)" );
@@ -100,7 +100,7 @@ __EOCFG__
 
     my $bcfg = Test::Smoke::BuildCFG->new( \$dft_cfg => { v => $verbose } );
 
-    is_deeply $bcfg->{_sections}, $dft_sect, 
+    is_deeply $bcfg->{_sections}, $dft_sect,
               "Empty lines at end of section kept";
 
     my $first = ( $bcfg->configurations )[0];
@@ -109,11 +109,11 @@ __EOCFG__
     foreach my $config ( $bcfg->configurations ) {
         if ( ($config->policy)[0]->[1] ) {
             ok( $config->has_arg( '-DDEBUGGING' ), "has_arg(-DDEBUGGING)" );
-            like( "$config", '/-DDEBUGGING/', 
+            like( "$config", '/-DDEBUGGING/',
                   "'$config' has -DDEBUGGING" );
         } else {
             ok( !$config->has_arg( '-DDEBUGGING' ), "! has_arg(-DDEBUGGING)" );
-            unlike( "$config", '/-DDEBUGGING/', 
+            unlike( "$config", '/-DDEBUGGING/',
                     "'$config' has no -DDEBUGGING" );
         }
         ok( $config->args_eq( "$config" ), "Stringyfied: args_eq($config)" );
@@ -181,7 +181,7 @@ __EOCFG__
 __EOCFG__
 
     my $dft_sect = [
-        { policy_target => '-DPERL_COPY_ON_WRITE', 
+        { policy_target => '-DPERL_COPY_ON_WRITE',
           args          => [ '', '-DPERL_COPY_ON_WRITE'] },
         [ '', '-Duseithreads' ],
         { policy_target => '-DDEBUGGING', args => [ '', '-DDEBUGGING'] },
@@ -189,7 +189,7 @@ __EOCFG__
 
     my $bcfg = Test::Smoke::BuildCFG->new( \$dft_cfg => { v => $verbose } );
 
-    is_deeply [ $bcfg->policy_targets ], 
+    is_deeply [ $bcfg->policy_targets ],
               [qw( -DPERL_COPY_ON_WRITE -DDEBUGGING )],
               "Policy targets...";
 
@@ -234,7 +234,7 @@ OUT
     my @not_seen;
     push @not_seen, "$_" for $bcfg->configurations;
 
-    is_deeply( \@not_seen, ["-Dusedevel -Dusethreads", 
+    is_deeply( \@not_seen, ["-Dusedevel -Dusethreads",
                             "-Dusedevel -Dusethreads -DDEBUGGING" ],
                "The right configs are left for continue" );
     1 while unlink 'mktest.out';

--- a/t/cfgstuff.t
+++ b/t/cfgstuff.t
@@ -58,7 +58,7 @@ SKIP: {
                             policy_target => '-DDEBUGGING'} ],
                "Parse test configuration" );
 
-    ok( unlink( $get_cfg ), "Clean-up" ) 
+    ok( unlink( $get_cfg ), "Clean-up" )
         or diag "$get_cfg: $!";
 }
 

--- a/t/for_nmake.t
+++ b/t/for_nmake.t
@@ -5,7 +5,7 @@ use File::Spec;
 
 use Test::More tests => 77;
 BEGIN { use_ok( 'Test::Smoke::Util' ); }
-END { 
+END {
     1 while unlink 'win32/smoke.mk';
     chdir File::Spec->updir
         if -d File::Spec->catdir( File::Spec->updir, 't' );
@@ -138,9 +138,9 @@ SKIP: {
     like( $makefile, '/^EMAIL\s*= abeltje\@cpan\.org\n/m', '$(EMAIL) set' );
 
     # This should now be set twice
-    like( $makefile, '/^CCTYPE\s*= MSVC60\nCCTYPE\s*= MSVC60\n/m', 
+    like( $makefile, '/^CCTYPE\s*= MSVC60\nCCTYPE\s*= MSVC60\n/m',
           '$(CCTYPE) set twice' );
-    like( $makefile, '/^\s*CCTYPE=\$\(CCTYPE\) > somewhere\n/m', 
+    like( $makefile, '/^\s*CCTYPE=\$\(CCTYPE\) > somewhere\n/m',
           "Untuched CCTYPE" );
 }
 

--- a/t/get_patch.t
+++ b/t/get_patch.t
@@ -98,7 +98,7 @@ SKIP: {
     1 while unlink '.patch';
 }
 
-END { 
+END {
     1 while unlink 'patchlevel.h';
     chdir File::Spec->updir
         if -d File::Spec->catdir( File::Spec->updir, 't' );

--- a/t/grepccmsg.t
+++ b/t/grepccmsg.t
@@ -13,7 +13,7 @@ use Test::More;
 
 my @logs;
 BEGIN {
-    @logs = ( 
+    @logs = (
         { file => 'w32bcc32.log', type => 'bcc32',
           wcnt => 12, ecnt => 1, lcnt => 13 },
         { file => 'solaris.log',  type => 'solaris',
@@ -23,7 +23,7 @@ BEGIN {
         { file => 'hpux1111.log', type => 'hpux',
           wcnt =>  2, ecnt => 0, lcnt => 2 },
         { file => 'mingw.log',    type => 'gcc',
-          wcnt =>  1, ecnt => 0, lcnt => 32 }, 
+          wcnt =>  1, ecnt => 0, lcnt => 32 },
         { file => 'icc102.log',   type => 'icc',
           wcnt =>  5, ecnt => 2, lcnt => 7 },
         { file => 'icc102.log',   type => 'icpc',

--- a/t/grepnonfatal.t
+++ b/t/grepnonfatal.t
@@ -13,7 +13,7 @@ use Test::More;
 
 my @logs;
 BEGIN {
-    @logs = ( 
+    @logs = (
         { file => 'w32bcc32.log',   type => 'bcc32',
           wcnt =>  0, ecnt => 0, lcnt => 0 },
         { file => 'solaris.log',    type => 'solaris',
@@ -23,7 +23,7 @@ BEGIN {
         { file => 'hpux1111.log',   type => 'hpux',
           wcnt =>  0, ecnt => 0, lcnt => 0 },
         { file => 'mingw.log',      type => 'gcc',
-          wcnt =>  0, ecnt => 0, lcnt => 0 }, 
+          wcnt =>  0, ecnt => 0, lcnt => 0 },
         { file => 'icc102.log',     type => 'icc',
           wcnt =>  0, ecnt => 0, lcnt => 0 },
         { file => 'icc102.log',     type => 'icpc',

--- a/t/lpatches.t
+++ b/t/lpatches.t
@@ -12,7 +12,7 @@ use TestLib;
 use File::Copy;
 
 use Test::More tests => 15;
-BEGIN { 
+BEGIN {
     use_ok 'Test::Smoke::Util', qw( get_local_patches set_local_patch );
 }
 my $verbose = $ENV{SMOKE_VERBOSE} || 0;

--- a/t/mailer.t
+++ b/t/mailer.t
@@ -46,16 +46,16 @@ SKIP: {
 
     my @config = parse_report_Config( $mailer->{body} );
     my @conf = @{ $eg_config }{qw(version plevel os osvers arch sum branch)};
-    
+
     is_deeply( \@config, \@conf, "Config..." );
     my $subj = sprintf "Smoke [%s] %s %s %s %s (%s)", @conf[6, 1, 5, 2, 3, 4];
-    
+
     is( $subject, $subj, "Read the report: $subject" );
     is( $mailer->{body}, $report, "Report read back ok" );
 
     # Now we try to test the new ccp5p_onfail stuff
     # and the new cc behaviour: no cc unless fail
-    is( $mailer->_get_cc( $subject ), '', 
+    is( $mailer->_get_cc( $subject ), '',
         "p5p not added to cc-list [--noccp5p_onfail]" );
     $mailer->{ccp5p_onfail} = 1;
     is( $mailer->_get_cc( $subject ), '',
@@ -88,7 +88,7 @@ SKIP: {
 
     my @config = parse_report_Config( $mailer->{body} );
     my @conf = @{ $fail_cfg }{qw(version plevel os osvers arch sum branch)};
-    
+
     is_deeply( \@config, \@conf, "Config..." );
     my $subj = sprintf "Smoke [%s] %s %s %s %s (%s)", @conf[6, 1, 5, 2, 3, 4];
 
@@ -96,19 +96,19 @@ SKIP: {
     is( $mailer->{body}, $report, "Report read back ok" );
 
     # Now we try to test the new ccp5p_onfail stuff
-    is( $mailer->_get_cc( $subject ), 'abeltje@test-smoke.org', 
+    is( $mailer->_get_cc( $subject ), 'abeltje@test-smoke.org',
         "p5p not added to cc-list [--noccp5p_onfail]" );
     $mailer->{ccp5p_onfail} = 1;
-    is( $mailer->_get_cc( $subject ), 
+    is( $mailer->_get_cc( $subject ),
         'abeltje@test-smoke.org, ' . $Test::Smoke::Mailer::P5P,
         "p5p got added to cc-list [--ccp5p_onfail]" );
     my $old_to = $mailer->{to};
     $mailer->{to} .= ", $Test::Smoke::Mailer::P5P";
-    is( $mailer->_get_cc( $subject ), 'abeltje@test-smoke.org', 
+    is( $mailer->_get_cc( $subject ), 'abeltje@test-smoke.org',
         "p5p not added to cc-list [already in To:]" );
     $mailer->{to} = $old_to;
     $mailer->{cc} = $Test::Smoke::Mailer::P5P;
-    is( $mailer->_get_cc( $subject ), $Test::Smoke::Mailer::P5P, 
+    is( $mailer->_get_cc( $subject ), $Test::Smoke::Mailer::P5P,
         "p5p not added to cc-list [already in Cc:]" );
     1 while unlink File::Spec->catfile( 't', 'mktest.rpt' );
 }
@@ -131,7 +131,7 @@ SKIP: {
 
     my @config = parse_report_Config( $mailer->{body} );
     my @conf = @{ $eg_config }{qw(version plevel os osvers arch sum branch)};
-    
+
     is_deeply( \@config, \@conf, "Config..." );
     my $subj = sprintf "Smoke [%s] %s %s %s %s (%s)", @conf[6, 1, 5, 2, 3, 4];
 
@@ -158,7 +158,7 @@ SKIP: {
 
     my @config = parse_report_Config( $mailer->{body} );
     my @conf = @{ $eg_config }{qw(version plevel os osvers arch sum branch)};
-    
+
     is_deeply( \@config, \@conf, "Config..." );
     my $subj = sprintf "Smoke [%s] %s %s %s %s (%s)", @conf[6, 1, 5, 2, 3, 4];
 
@@ -187,7 +187,7 @@ SKIP: {
 
     my @config = parse_report_Config( $mailer->{body} );
     my @conf = @{ $eg_config }{qw(version plevel os osvers arch sum branch)};
-    
+
     is_deeply( \@config, \@conf, "Config..." );
     my $subj = sprintf "Smoke [%s] %s %s %s %s (%s)", @conf[6, 1, 5, 2, 3, 4];
 

--- a/t/parse_report.t
+++ b/t/parse_report.t
@@ -57,7 +57,7 @@ __EOR__
 
     my %conf;
 
-    @conf{qw( version plevel os osvers arch sum ) } = 
+    @conf{qw( version plevel os osvers arch sum ) } =
         parse_report_Config( $report );
     $conf{ccvers} = $ccvers if $eg->{ccvers};
     $conf{cpu} = $cpu if $eg->{cpu};

--- a/t/patcher.t
+++ b/t/patcher.t
@@ -26,7 +26,7 @@ my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
     # Check that the default values are returned
     for my $attr (qw( pfile patchbin popts v )) {
-        is( $patcher->{ $attr }, $df_vals->{ $attr }, 
+        is( $patcher->{ $attr }, $df_vals->{ $attr },
             "'$attr' attribute" );
     }
 
@@ -73,7 +73,7 @@ SKIP: { # test Test::Smoke::Patcher->patch_single()
 
     my $reverse1 = File::Spec->catfile( File::Spec->updir, 'test.patch' );
     local *MYPATCH;
-    open MYPATCH, "> $testpatch" or 
+    open MYPATCH, "> $testpatch" or
         skip "Cannont create '$testpatch': $!", $to_skip -= 4;
     binmode MYPATCH;
     print MYPATCH $p_content;

--- a/t/policy.t
+++ b/t/policy.t
@@ -90,7 +90,7 @@ sub run_tests {
         # If more than 1 value wishes to substitute, join them with spaces
         my $this_policy = $policy;
         while (my ($target, $values) = each %substs) {
-#diag( "TRADITIONAL: '$target'-> '@$values' " , 
+#diag( "TRADITIONAL: '$target'-> '@$values' " ,
 #      ($this_policy=~/^(ccflags.*)/m) );
             unless ($this_policy =~ s/$target/join " ", @$values/seg) {
                 warn "Policy target '$target' failed to match";
@@ -104,7 +104,7 @@ sub run_tests {
         my @new = grep ! /^#/ => split /\n/, $pobj->{_new_policy};
 #diag( Dumper \@old, \@new );
         is_deeply( \@new, \@old, "Policy.sh up-to-date: $config_args" );
-      
+
     }
 }
 

--- a/t/regenstuff.t
+++ b/t/regenstuff.t
@@ -10,7 +10,7 @@ use lib $findbin;
 use TestLib;
 
 use Test::More tests => 11;
-BEGIN { 
+BEGIN {
     use_ok( 'Test::Smoke::Util', qw( get_regen_headers run_regen_headers ) );
 }
 
@@ -27,7 +27,7 @@ SKIP: { # Find 'regen_headers.pl'
     my $to_skip = 2;
     local *FILE;
     my $regen_headers_pl = File::Spec->catfile( $ddir, 'regen_headers.pl' );
-    open( FILE, "> $regen_headers_pl" ) 
+    open( FILE, "> $regen_headers_pl" )
         or skip "Cannot create '$regen_headers_pl': $!", $to_skip;
     print FILE <<EO_REGEN;
 #! $^X -w
@@ -57,7 +57,7 @@ SKIP: { # Prefer 'regen_headers.pl' over 'regen.pl'
     local *FILE;
     my $regen_headers_pl = File::Spec->catfile( $ddir, 'regen_headers.pl' );
     my $regen_pl = File::Spec->catfile( $ddir, 'regen.pl' );
-    open( FILE, "> $regen_pl" ) 
+    open( FILE, "> $regen_pl" )
         or skip "Cannot create '$regen_pl': $!", $to_skip;
     print FILE <<EO_REGEN;
 #! $^X -w
@@ -87,7 +87,7 @@ SKIP: { # as of 18852: 'regen_headers.pl' is now 'regen.pl'
     my $regen_headers_pl = File::Spec->catfile( $ddir, 'regen_headers.pl' );
     my $regen_pl = File::Spec->catfile( $ddir, 'regen.pl' );
 
-    unlink $regen_headers_pl 
+    unlink $regen_headers_pl
         or skip "Cannot unlink($regen_headers_pl): $!", $to_skip--;
 
     my $regen = get_regen_headers( $ddir );

--- a/t/reporter.t
+++ b/t/reporter.t
@@ -50,7 +50,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -87,7 +87,7 @@ Stopped smoke at @{ [$timer += 100] }
 EORESULTS
 
     is( $reporter->{_rpt}{started}, $timer - 300, "Start time" );
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -110,7 +110,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'PASS', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 #    diag Dumper $reporter->{_counters};
@@ -121,7 +121,7 @@ for my $p (@patchlevels) {
     create_config_sh( $config_sh, version => '5.8.3' );
     my $reporter = Test::Smoke::Reporter->new(
         ddir    => $findbin,
-        v       => $verbose, 
+        v       => $verbose,
         outfile => '',
         showcfg => $showcfg,
         cfg     => \( my $bcfg = <<__EOCFG__ ),
@@ -214,10 +214,10 @@ __EOM__
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
     if ( $showcfg ) {
-         like $reporter->report, "/Build configurations:\n$bcfg=/", 
+         like $reporter->report, "/Build configurations:\n$bcfg=/",
               "has the configurations";
     } else {
-         unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+         unlike $reporter->report, "/Build configurations:\n$bcfg=/",
                 "hasn't the configurations";
     }
 
@@ -229,7 +229,7 @@ for my $p (@patchlevels) {
     create_config_sh( $config_sh, version => '5.9.0' );
     my $reporter = Test::Smoke::Reporter->new(
         ddir    => $findbin,
-        v       => $verbose, 
+        v       => $verbose,
         outfile => '',
     );
     isa_ok( $reporter, 'Test::Smoke::Reporter' );
@@ -320,9 +320,9 @@ unlink $config_sh;
 for my $p (@patchlevels) {
     # This test is just to test 'PASS' (and not PASS-so-far)
     #    create_config_sh( $config_sh, version => '5.00504' );
-    my $reporter = Test::Smoke::Reporter->new( 
+    my $reporter = Test::Smoke::Reporter->new(
         ddir    => $findbin,
-        v       => $verbose, 
+        v       => $verbose,
         outfile => '',
         is56x   => 1,
     );
@@ -417,10 +417,10 @@ __EOM__
     $r or diag $reporter->smoke_matrix, $reporter->bldenv_legend;
 
     if ( $showcfg ) {
-         like $reporter->report, "/Build configurations:\n$bcfg=/", 
+         like $reporter->report, "/Build configurations:\n$bcfg=/",
               "has the configurations";
     } else {
-         unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+         unlike $reporter->report, "/Build configurations:\n$bcfg=/",
                 "hasn't the configurations";
     }
 
@@ -450,7 +450,7 @@ for my $p (@patchlevels) {
 __EOCFG__
     ), "new reporter for bugtst02.out" );
     isa_ok $reporter, 'Test::Smoke::Reporter';
-    is $reporter->ccinfo, "gcc version 3.3.1 (cygming special)", 
+    is $reporter->ccinfo, "gcc version 3.3.1 (cygming special)",
        "ccinfo(bugstst02)";
 
     is( $reporter->{_rpt}{patch}, $p->[0],
@@ -476,10 +476,10 @@ __EOM__
     $r or diag $reporter->smoke_matrix, $reporter->bldenv_legend;
 
     if ( $showcfg ) {
-         like $reporter->report, "/Build configurations:\n$bcfg=/", 
+         like $reporter->report, "/Build configurations:\n$bcfg=/",
               "has the configurations";
     } else {
-         unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+         unlike $reporter->report, "/Build configurations:\n$bcfg=/",
                 "hasn't the configurations";
     }
 
@@ -559,10 +559,10 @@ __EOM__
     $r or diag $reporter->smoke_matrix, $reporter->bldenv_legend;
 
     if ( $showcfg ) {
-         like $reporter->report, "/Build configurations:\n$bcfg=/", 
+         like $reporter->report, "/Build configurations:\n$bcfg=/",
               "has the configurations";
     } else {
-         unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+         unlike $reporter->report, "/Build configurations:\n$bcfg=/",
                 "hasn't the configurations";
     }
     my @f_lines = split /\n/, $reporter->failures;
@@ -623,7 +623,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -667,7 +667,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -693,7 +693,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -726,7 +726,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -764,7 +764,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -790,7 +790,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'PASS', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -817,7 +817,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -856,7 +856,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -882,7 +882,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -913,7 +913,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -950,7 +950,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -976,7 +976,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1005,7 +1005,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1042,7 +1042,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1068,7 +1068,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(X)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1097,7 +1097,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1142,7 +1142,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1168,7 +1168,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1201,7 +1201,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1306,7 +1306,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1332,7 +1332,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1395,7 +1395,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1450,7 +1450,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1482,7 +1482,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'PASS', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1509,7 +1509,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1564,7 +1564,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1596,7 +1596,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'PASS', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1635,7 +1635,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1668,7 +1668,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1692,7 +1692,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1714,7 +1714,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1751,7 +1751,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1775,7 +1775,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 
@@ -1798,7 +1798,7 @@ for my $p (@patchlevels) {
 
     my $reporter = Test::Smoke::Reporter->new(
         ddir       => $findbin,
-        v          => $verbose, 
+        v          => $verbose,
         outfile    => '',
         showcfg    => $showcfg,
         cfg        => \( my $bcfg = <<__EOCFG__ ),
@@ -1829,7 +1829,7 @@ Finished smoking $patch
 Stopped smoke at 1258883821
 EORESULTS
 
-    is( $reporter->{_rpt}{patch}, $p->[0], 
+    is( $reporter->{_rpt}{patch}, $p->[0],
         "Changenumber $reporter->{_rpt}{patch}" );
     is( $reporter->{_rpt}{patchdescr}, $p->[1] || $p->[0],
         "Changedescr $reporter->{_rpt}{patchdescr}" );
@@ -1853,7 +1853,7 @@ __EOM__
 
     chomp( my $summary = $reporter->summary );
     is $summary, 'FAIL(F)', $summary;
-    unlike $reporter->report, "/Build configurations:\n$bcfg=/", 
+    unlike $reporter->report, "/Build configurations:\n$bcfg=/",
             "hasn't the configurations";
 
 

--- a/t/skip_filter.t
+++ b/t/skip_filter.t
@@ -58,7 +58,7 @@ for my $test ( @tests ) {
     while (<$tst>) {
         chomp;
         skip_filter($_) and next;
-        m/^u=.*tests=/ and next;        
+        m/^u=.*tests=/ and next;
         (my $tname = $_) =~ s/\s*\.+.*/.t/;
         push @nok, $tname;
     }

--- a/t/smoked_config.t
+++ b/t/smoked_config.t
@@ -30,12 +30,12 @@ SKIP: {
     my $cfg_nm = 'Config_heavy.pl';
     my $to_skip = 5;
     my $libpath = File::Spec->catdir( $findbin, 'lib' );
-    -d $libpath or mkpath( $libpath )  or 
+    -d $libpath or mkpath( $libpath )  or
         skip "Can't create '$libpath': $!", $to_skip;
     $Config_heavy = File::Spec->catfile( $libpath, $cfg_nm );
 
     local *CONFIGPM;
-    open CONFIGPM, "> $Config_heavy" or 
+    open CONFIGPM, "> $Config_heavy" or
         skip "Can't create '$Config_heavy': $!", $to_skip;
 
     print CONFIGPM <<EOCONFIG;
@@ -69,12 +69,12 @@ EOCONFIG
 SKIP: {
     my $to_skip = 5;
     my $libpath = File::Spec->catdir( $findbin, 'lib' );
-    -d $libpath or mkpath( $libpath )  or 
+    -d $libpath or mkpath( $libpath )  or
         skip "Can't create '$libpath': $!", $to_skip;
     $Config_pm = File::Spec->catfile( $libpath, 'Config.pm' );
 
     local *CONFIGPM;
-    open CONFIGPM, "> $Config_pm" or 
+    open CONFIGPM, "> $Config_pm" or
         skip "Can't create '$Config_pm': $!", $to_skip;
 
     print CONFIGPM <<EOCONFIG;
@@ -110,7 +110,7 @@ SKIP: { # get info from config.sh
     $Config_sh = File::Spec->catfile( $libpath, 'config.sh' );
 
     local *CONFIGSH;
-    open CONFIGSH, "> $Config_sh" or 
+    open CONFIGSH, "> $Config_sh" or
         skip "Can't create '$Config_sh': $!", $to_skip;
 
     print CONFIGSH <<EOCONFIG;
@@ -149,7 +149,7 @@ EOCONFIG
     my $no_files = 1;
     $no_files &&= ! -e $_ for grep defined $_
         => ( $Config_heavy, $Config_pm, $Config_sh );
-    ok( $no_files, "Config from: fallback" ); 
+    ok( $no_files, "Config from: fallback" );
     is( $Config{archname}, $arch, "Architecture $arch" );
     is( $Config{osname}, $osname, "OS name: $osname" );
     is( $Config{osvers}, $osvers, "OS version: $osvers" );
@@ -161,7 +161,7 @@ SKIP: {
     my $to_skip = 4;
 
     local *PL_H;
-    open PL_H, "> $patchlevel_h" or 
+    open PL_H, "> $patchlevel_h" or
         skip "Can't create '$Config_pm': $!", $to_skip;
 
     print PL_H <<EOPL;
@@ -188,7 +188,7 @@ SKIP: {
     my $to_skip = 4;
 
     local *PL_H;
-    open PL_H, "> $patchlevel_h" or 
+    open PL_H, "> $patchlevel_h" or
         skip "Can't create '$Config_pm': $!", $to_skip;
 
     print PL_H <<EOPL;
@@ -230,7 +230,7 @@ SKIP: {
     my $to_skip = 5;
 
     local *CONFIGPM;
-    open CONFIGPM, "> $Config_pm" or 
+    open CONFIGPM, "> $Config_pm" or
         skip "Can't create '$Config_pm': $!", $to_skip;
 
     print CONFIGPM <<EOCONFIG;

--- a/t/smoker.t
+++ b/t/smoker.t
@@ -29,11 +29,11 @@ open LOG, "> " . devnull();
     my $smoker = Test::Smoke::Smoker->new( \*LOG, %config );
     isa_ok( $smoker, 'Test::Smoke::Smoker' );
 
-    my $ref = mkargs( \%config, 
+    my $ref = mkargs( \%config,
                       Test::Smoke::Smoker->config( 'all_defaults' ) );
     $ref->{logfh} = \*LOG;
 
-    is_deeply( $smoker, $ref, "Check arguments" );   
+    is_deeply( $smoker, $ref, "Check arguments" );
 
     close LOG;
 }
@@ -925,7 +925,7 @@ SKIP: {
     $ok &&= grep $files =~ /^\Q$_\E/m => @libext;
     ok $ok, "files back in MANIFEST";
 
-    1 while unlink $skip_tests;    
+    1 while unlink $skip_tests;
 }
     rmtree $dst, $verbose;
 }
@@ -935,7 +935,7 @@ sub mkargs {
 
     my %mkargs = map {
 
-        my $value = exists $set->{ $_ } 
+        my $value = exists $set->{ $_ }
             ? $set->{ $_ } : Test::Smoke::Smoker->config( $_ );
         ( $_ => $value )
     } keys %$default;

--- a/t/syncer_copy.t
+++ b/t/syncer_copy.t
@@ -99,7 +99,7 @@ SKIP: {
     is( $dcnt, 0, "No other files have been added" );
 }
 
-END { 
+END {
     unless ( $ENV{SMOKE_DEBUG} ) {
       rmtree( $ddir );
       rmtree( $cdir );

--- a/t/syncer_ftp.t
+++ b/t/syncer_ftp.t
@@ -10,7 +10,7 @@ use strict;
 # For this there is the 't/ftppub' directory with:
 #     't/ftppub/snap' contains two fake snapshots (with files)
 #     't/ftppub/perl-current-diffs' contains a few fake diffs
-# Now that we have controlable FTP (if you have Net::FTP), 
+# Now that we have controlable FTP (if you have Net::FTP),
 # we can concentrate on doing the untargz and patch stuff
 #
 #####
@@ -25,7 +25,7 @@ use Test::More;
 
 BEGIN {
     eval { require Net::FTP; };
-    $@ and plan( skip_all => "No 'Net::FTP' found!\n" . 
+    $@ and plan( skip_all => "No 'Net::FTP' found!\n" .
                              "!!!You will not be able to smoke from " .
                              "snapshots without it!!!" );
     plan tests => 7;
@@ -41,12 +41,12 @@ sub Net::FTP::new { bless {}, 'Net::FTP' }
 sub Net::FTP::login { return 1 }
 sub Net::FTP::binary { return 1 }
 sub Net::FTP::quit {return 1 }
-sub Net::FTP::cwd { 
+sub Net::FTP::cwd {
     my $self = shift;
     ( my $dir = shift ) =~ s|^.*/||;
     $self->{cwd} = File::Spec->catdir( 't', 'ftppub', $dir );
 }
-sub Net::FTP::ls { 
+sub Net::FTP::ls {
     my $self = shift;
     local *DLDIR;
     opendir DLDIR, $self->{cwd} or return ( );

--- a/t/syncer_ftpclient.t
+++ b/t/syncer_ftpclient.t
@@ -11,7 +11,7 @@ use Data::Dumper;
 # For this there is the 't/ftppub' directory with:
 #     't/ftppub/perl-current' contains a source-tree
 #     't/ftppub/perl-current-diffs' contains a few fake diffs
-# Now that we have controlable FTP (if you have Net::FTP), 
+# Now that we have controlable FTP (if you have Net::FTP),
 # we can concentrate on doing the untargz and patch stuff
 #
 #####
@@ -33,7 +33,7 @@ use Test::More;
 
 BEGIN {
     eval { require Net::FTP; };
-    $@ and plan( skip_all => "No 'Net::FTP' found!\n" . 
+    $@ and plan( skip_all => "No 'Net::FTP' found!\n" .
                              "!!!You will not be able to smoke from " .
                              "FTP-archive without it!!!" );
     plan tests => 12;
@@ -51,7 +51,7 @@ sub Net::FTP::new {
 sub Net::FTP::login { return 1 }
 sub Net::FTP::binary { return 1 }
 sub Net::FTP::quit {return 1 }
-sub Net::FTP::cwd { 
+sub Net::FTP::cwd {
     my $self = shift;
     my $dir = shift;
     if ( $dir eq '/' ) {
@@ -67,7 +67,7 @@ sub Net::FTP::pwd {
     my $self = shift;
     File::Spec->abs2rel( $self->{cwd}, $self->{root} );
 }
-sub Net::FTP::ls { 
+sub Net::FTP::ls {
     my $self = shift;
     local *DLDIR;
     opendir DLDIR, $self->{cwd} or return ( );
@@ -107,7 +107,7 @@ sub Net::FTP::dir {
 #                                                 $info[7], $lsldate, $_;
         sprintf "%s  1 %-8s %-8s %10d %12s %s", $lslmode, 'ftp', 'ftp',
                                                  $info[7], $lsldate, $_;
-    } @list; 
+    } @list;
 }
 sub Net::FTP::size {
     my $self = shift;
@@ -166,7 +166,7 @@ require_ok 'Test::Smoke::SourceTree';
     {
         my $tree = Test::Smoke::SourceTree->new( $stree );
         my $mc = $tree->check_MANIFEST;
-    
+
         is scalar keys %$mc, 0, "No files in manicheck" or
             diag Dumper $mc;
     }
@@ -184,7 +184,7 @@ require_ok 'Test::Smoke::SourceTree';
     {
         my $tree = Test::Smoke::SourceTree->new( $stree );
         my $mc = $tree->check_MANIFEST;
-    
+
         is scalar keys %$mc, 0, "No files in manicheck (resync)" or
             diag Dumper $mc;
     }
@@ -194,6 +194,6 @@ require_ok 'Test::Smoke::SourceTree';
     $FTP_FAIL = 1;
     $plevel = $sync->sync;
     is $plevel, undef, "no sync on failing FTP";
-    
+
     ok rmtree( $stree ), "Clean-up";
 }

--- a/t/syncer_link.t
+++ b/t/syncer_link.t
@@ -89,7 +89,7 @@ SKIP: { # Check that the same works for {haslink} == 0
     my $tar = find_uncompress() or
         skip "Cannot find decompression stuff", $to_skip;
 
-    do_uncompress( $tar, 't', 
+    do_uncompress( $tar, 't',
                    File::Spec->catfile(qw( ftppub snap perl@20000.tgz )) ) or
         skip "Cannot decompress testsnapshot", $to_skip;
 
@@ -143,7 +143,7 @@ sub do_uncompress {
 
     # I cannot use Test::Smoke::Syncer::Snapshot to extract
     # but I need check_dot_patch() for the tests
-    my $syncer = Test::Smoke::Syncer->new( snapshot => { 
+    my $syncer = Test::Smoke::Syncer->new( snapshot => {
         v    => 2,
         ddir => 'perl',
     });

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -31,41 +31,41 @@ my %df_rsync = (
 }
 {
     my %rsync = %df_rsync;
-    $rsync{source} = 'ftp.linux.ActiveState.com::perl-current'; 
+    $rsync{source} = 'ftp.linux.ActiveState.com::perl-current';
     $rsync{ddir}   = File::Spec->canonpath(abs_path(cwd()));
-    my $sync = eval { 
-        Test::Smoke::Syncer->new( 'rsync', 
+    my $sync = eval {
+        Test::Smoke::Syncer->new( 'rsync',
             source => $rsync{source},
             -ddir  => $rsync{ddir},
             nonsence => 'who cares',
-        ) 
+        )
     };
     ok( !$@, "No error on type 'rsync'" );
     isa_ok( $sync, 'Test::Smoke::Syncer::Rsync' );
     for my $field (sort keys %rsync ) {
         ok( exists $sync->{ $field }, "{$field} exists" ) or
             skip "expected {$field} but is not there", 1;
-        is( $sync->{ $field }, $rsync{ $field }, 
+        is( $sync->{ $field }, $rsync{ $field },
             "{$field} value $sync->{ $field }" );
     }
 }
 {
     my %rsync = %df_rsync;
-    $rsync{source} = 'ftp.linux.ActiveState.com::perl-current'; 
+    $rsync{source} = 'ftp.linux.ActiveState.com::perl-current';
     $rsync{ddir}   = File::Spec->canonpath(abs_path(cwd()));
-    my $sync = eval { 
+    my $sync = eval {
         Test::Smoke::Syncer->new( rsync => {
             source => $rsync{source},
             -ddir  => $rsync{ddir},
             nonsense => 'who cares',
-        }) 
+        })
     };
     ok( !$@, "No errror when options passed as hashref" );
     isa_ok( $sync, 'Test::Smoke::Syncer::Rsync' );
     for my $field (sort keys %rsync ) {
         ok( exists $sync->{ $field }, "{$field} exists" ) or
             skip "expected {$field} but is not there", 1;
-        is( $sync->{ $field }, $rsync{ $field }, 
+        is( $sync->{ $field }, $rsync{ $field },
             "{$field} value $sync->{ $field }" );
     }
 }

--- a/t/syncer_snap.t
+++ b/t/syncer_snap.t
@@ -17,6 +17,6 @@ use_ok( 'Test::Smoke::Syncer' );
 
     isa_ok( $syncer, 'Test::Smoke::Syncer::Snapshot' );
 
-    is( $syncer->{server}, Test::Smoke::Syncer->config( 'server' ), 
+    is( $syncer->{server}, Test::Smoke::Syncer->config( 'server' ),
         "ftp server for snapshot" );
 }

--- a/t/tree.t
+++ b/t/tree.t
@@ -18,7 +18,7 @@ sub mani_file_from_list($;@) {
     print MANIFEST "$_\n" for grep length $_ => @list;
     close MANIFEST;
 }
-    
+
 sub MANIFEST_from_dir($) {
     my( $path ) = @_;
 
@@ -111,14 +111,14 @@ SKIP: { # Check that check_MANIFEST() finds dubious files
     my $undeclared = File::Spec->catfile( 't', 'undeclared' );
     $undeclared = File::Spec->rel2abs( $undeclared );
     {
-        open FH, "> $undeclared" or 
+        open FH, "> $undeclared" or
             skip "Cannot create '$undeclared': $!", 3;
         close FH;
     }
     my $skipit = File::Spec->catfile( 't', 'skip_it' );
     $skipit = File::Spec->rel2abs( $skipit );
     {
-        open FH, "> $skipit" or 
+        open FH, "> $skipit" or
             skip "Cannot create '$skipit': $!", 3;
         close FH;
     }
@@ -166,14 +166,14 @@ SKIP: { # Check that check_MANIFEST() finds dubious files with MANIFEST.SKIP
     my $undeclared = File::Spec->catfile( 't', 'undeclared' );
     $undeclared = File::Spec->rel2abs( $undeclared );
     {
-        open FH, "> $undeclared" or 
+        open FH, "> $undeclared" or
             skip "Cannot create '$undeclared': $!", 3;
         close FH;
     }
     my $skipit = File::Spec->catfile( 't', 'skip_it' );
     $skipit = File::Spec->rel2abs( $skipit );
     {
-        open FH, "> $skipit" or 
+        open FH, "> $skipit" or
             skip "Cannot create '$skipit': $!", 3;
         close FH;
     }

--- a/t/ts_config.t
+++ b/t/ts_config.t
@@ -10,7 +10,7 @@ use vars qw( $conf );
 use Test::More tests => 9 - 1;
 BEGIN { use_ok( 'Test::Smoke' ) }
 
-#is( Test::Smoke->VERSION, $Test::Smoke::VERSION, 
+#is( Test::Smoke->VERSION, $Test::Smoke::VERSION,
 #    "Check version $Test::Smoke::VERSION" );
 
 ok( defined &read_config, "read_config() is exported" );
@@ -19,7 +19,7 @@ my $test = { ddir => '../' };
 
 SKIP: {
     my $prefix = 'smokecurrent';
-    my $config_name = File::Spec->catfile( $FindBin::Bin, 
+    my $config_name = File::Spec->catfile( $FindBin::Bin,
                                            "${prefix}_config" );
     local *FILE;
     open FILE, "> $config_name" or skip "Cannot write file: $!", 2;
@@ -39,4 +39,4 @@ SKIP: {
     1 while unlink $config_name;
 }
 
-    
+

--- a/xt/01-compile.t
+++ b/xt/01-compile.t
@@ -7,7 +7,7 @@ use File::Find;
 my @to_compile;
 BEGIN {
     @to_compile = qw( smokeperl.pl runsmoke.pl
-                   synctree.pl patchtree.pl mailrpt.pl 
+                   synctree.pl patchtree.pl mailrpt.pl
                    archiverpt.pl smokestatus.pl W32Configure.pl
                    Makefile.PL configsmoke.pl chkbcfg.pl sysinfo.pl );
 

--- a/xt/20-smoker_fail.t
+++ b/xt/20-smoker_fail.t
@@ -82,7 +82,7 @@ use_ok( 'Test::Smoke::Smoker' );
         \\d+(?:[,\\s-]+\\d+)*\\s+
         (?:.+\\s)?
     /xm@, "Failures report" );
-          
+
 
     select( $verbose ? \*STDOUT : \*DEVNULL ); $| = 1;
     $smoker->make_distclean;
@@ -158,7 +158,7 @@ use_ok( 'Test::Smoke::Smoker' );
         \\d+(?:[,\\s-]+\\d+)*\\s+
         (?:.+\\s)?
     /xm@, "Failures report" );
-          
+
 
     select( $verbose ? \*STDOUT : \*DEVNULL ); $| = 1;
     $smoker->make_distclean;

--- a/xt/30-smoker_mini.t
+++ b/xt/30-smoker_mini.t
@@ -60,7 +60,7 @@ use_ok( 'Test::Smoke::Smoker' );
 
         $smoker->log( "\nConfiguration: $bcfg\n", '-' x 78, "\n" );
         my $stat = $smoker->make_;
-        is( $stat, Test::Smoke::Smoker::BUILD_MINIPERL(), 
+        is( $stat, Test::Smoke::Smoker::BUILD_MINIPERL(),
             "Could not build anything but 'miniperl'" );
         $smoker->log( "Unable to make anything but miniperl",
                       " in this configuration\n" );
@@ -84,7 +84,7 @@ use_ok( 'Test::Smoke::Smoker' );
         -DDEBUGGING \\s+
         t[\\\\/]smoke[\\\\/]minitest\\.+FAILED\\ at\\ test\\ 2
     /xm@, "Failures report" );
-          
+
 
     select( DEVNULL ); $| = 1;
     $smoker->make_distclean;

--- a/xt/40-smoker_ok.t
+++ b/xt/40-smoker_ok.t
@@ -122,7 +122,7 @@ It currently has two real options:
 
 This option will make sure that C<< S<make miniperl> >> will succeed,
 but C<make> (to create the F<perl> binary) will not succeed. This
-option enables us to test this situation and (later) check that 
+option enables us to test this situation and (later) check that
 C<< S<make minitest> >> is called instead of C<< S<make test> >>.
 
 =item B<--cc [path to cc]>

--- a/xt/50-smoker_smoke.t
+++ b/xt/50-smoker_smoke.t
@@ -73,7 +73,7 @@ use_ok( 'Test::Smoke::Smoker' );
         -DDEBUGGING.*\s+
         .*smoke\/minitest\.t\.+FAILED
     /xm@, "Failures report" );
-          
+
 
     select( DEVNULL ); $| = 1;
     $smoker->make_distclean;
@@ -143,7 +143,7 @@ use_ok( 'Test::Smoke::Smoker' );
         .*smoke\/minitest\.t\.+FAILED\s+
         \d(?:[, -]\d+)*
     /xm@, "Failures report" );
-          
+
 
     select( DEVNULL ); $| = 1;
     $smoker->make_distclean;

--- a/xt/SmokertestLib.pm
+++ b/xt/SmokertestLib.pm
@@ -6,7 +6,7 @@ use vars qw( $VERSION @EXPORT );
 $VERSION = '0.004';
 
 use base 'Exporter';
-@EXPORT = qw( 
+@EXPORT = qw(
     &clean_mktest_stuff
     &make_report &get_report
     &get_Win32_args
@@ -51,10 +51,10 @@ sub get_report {
 sub get_Win32_args {
     my %w32args  = ( w32cct => "", is_win32 => 0 );
     if ( $^O eq 'MSWin32' ) {
-        my $w32make = exists $ENV{SMOKE_W32MAKE} 
+        my $w32make = exists $ENV{SMOKE_W32MAKE}
             ? $ENV{SMOKE_W32MAKE} : 'dmake';
         $w32make ||= 'dmake';
-        my $w32cc = exists $ENV{SMOKE_W32CC} 
+        my $w32cc = exists $ENV{SMOKE_W32CC}
             ? $ENV{SMOKE_W32CC} : "GCC";
         $w32cc ||= "GCC";
         %w32args = (


### PR DESCRIPTION
These changes merely remove trailing whitespace from source code files.  This simply makes the code a little bit tidier and is something I noticed while reading the code recently.  I hope this helps in some way!