### PR TITLE
Remove Subversion Id tags

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -39,10 +39,6 @@ I changed my mind about version numbering. I'll just use X.YY from now on.
 
 =back
 
-=head1 REVISION
-
-$Id$
-
 =head1 COPYRIGHT
 
 (c) MMII-MMVIII, Abe Timmerman <abeltje@cpan.org> All rights reserved.

--- a/W32Configure.pl
+++ b/W32Configure.pl
@@ -3,7 +3,6 @@ use strict;
 $| = 1;
 # BEGIN { die "You must be on MSWin32 for this!\n" unless $^O eq 'MSWin32' }
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.007';
 

--- a/archiverpt.pl
+++ b/archiverpt.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.005';
 

--- a/chkbcfg.pl
+++ b/chkbcfg.pl
@@ -1,7 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
 use vars qw ( $VERSION );
 $VERSION = '0.002';
 

--- a/configsmoke.pl
+++ b/configsmoke.pl
@@ -2762,12 +2762,6 @@ sub _perl_numeric_version {
 
 Schedule, logfile optional
 
-=head1 REVISION
-
-In case I forget to update the C<$VERSION>:
-
-    $Id$
-
 =head1 COPYRIGHT
 
 (c) 2002-2003, All rights reserved.

--- a/configsmoke.pl
+++ b/configsmoke.pl
@@ -20,7 +20,6 @@ use fallback 'inc', 'lib', catdir($findbin, 'inc');
 use Test::Smoke::SysInfo;
 use Test::Smoke::Util qw(do_pod2usage whereis);
 
-# $Id$
 use vars qw($VERSION $conf);
 $VERSION = '0.082';
 

--- a/lib/Test/Smoke/BuildCFG.pm
+++ b/lib/Test/Smoke/BuildCFG.pm
@@ -1,7 +1,6 @@
 package Test::Smoke::BuildCFG;
 use strict;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.009';
 

--- a/lib/Test/Smoke/FAQ
+++ b/lib/Test/Smoke/FAQ
@@ -461,10 +461,6 @@ disagree (it was all before my time).
 The case is now that the official name for the mailinglist is
 B<daily-build-reports> and there is an alias to B<smokers-reports>.
 
-=head1 REVISION
-
-$Id$
-
 =head1 COPYRIGHT
 
 Copyright 2002-2003, Abe Timmerman <abeltje@cpan.org> All rights reserved.

--- a/lib/Test/Smoke/FTPClient.pm
+++ b/lib/Test/Smoke/FTPClient.pm
@@ -7,7 +7,6 @@ use File::Path;
 use File::Spec::Functions qw( :DEFAULT abs2rel rel2abs );
 use Test::Smoke::Util qw( clean_filename time_in_hhmm );
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.011';
 

--- a/lib/Test/Smoke/Patcher.pm
+++ b/lib/Test/Smoke/Patcher.pm
@@ -1,7 +1,6 @@
 package Test::Smoke::Patcher;
 use strict;
 
-# $Id$
 use vars qw( $VERSION @EXPORT );
 $VERSION = '0.012';
 

--- a/lib/Test/Smoke/Policy.pm
+++ b/lib/Test/Smoke/Policy.pm
@@ -1,7 +1,6 @@
 package Test::Smoke::Policy;
 use strict;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.004';
 

--- a/lib/Test/Smoke/SourceTree.pm
+++ b/lib/Test/Smoke/SourceTree.pm
@@ -1,7 +1,6 @@
 package Test::Smoke::SourceTree;
 use strict;
 
-# $Id$
 use vars qw( $VERSION @EXPORT_OK %EXPORT_TAGS $NOCASE );
 $VERSION = '0.008';
 

--- a/lib/Test/Smoke/Util.pm
+++ b/lib/Test/Smoke/Util.pm
@@ -1,7 +1,6 @@
 package Test::Smoke::Util;
 use strict;
 
-# $Id$
 use vars qw( $VERSION @EXPORT @EXPORT_OK $NOCASE );
 $VERSION = '0.58';
 

--- a/lib/Test/Smoke/perl58x.cfg
+++ b/lib/Test/Smoke/perl58x.cfg
@@ -1,5 +1,4 @@
 # This is a configuration file for the smoke tester.
-# $Id$
 # Lines starting with # are comments.
 # Lines starting with = are section breaks;
 # The rest of the line will be ignored.

--- a/lib/Test/Smoke/perlcurrent.cfg
+++ b/lib/Test/Smoke/perlcurrent.cfg
@@ -1,5 +1,4 @@
 # This is a configuration file for the smoke tester.
-# $Id$
 # Lines starting with # are comments.
 # Lines starting with = are section breaks;
 # The rest of the line will be ignored.

--- a/lib/Test/Smoke/perlmaint.cfg
+++ b/lib/Test/Smoke/perlmaint.cfg
@@ -1,5 +1,4 @@
 # This is a configuration file for the smoke tester.
-# $Id$
 # Lines starting with # are comments.
 # Lines starting with = are section breaks;
 # The rest of the line will be ignored.

--- a/lib/Test/Smoke/vmsperl.cfg
+++ b/lib/Test/Smoke/vmsperl.cfg
@@ -1,5 +1,4 @@
 # This is a configuration file for the smoke tester on OpenVMS.
-# $Id$
 # Lines starting with # are comments.
 # Lines starting with = are section breaks;
 # The rest of the line will be ignored.

--- a/lib/Test/Smoke/w32current.cfg
+++ b/lib/Test/Smoke/w32current.cfg
@@ -1,5 +1,4 @@
 # This is a cleaned up version of 'smoke.cfg' for MSWin32
-# $Id$
 # The Configure_win32 routine in Test::Smoke::Util has been expanded
 # to understand quite a lot of arguments from this file
 # please also look at the makefiles in the win32 subdirectory

--- a/mailrpt.pl
+++ b/mailrpt.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.017';
 

--- a/patchtree.pl
+++ b/patchtree.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.008';
 

--- a/provesmoke
+++ b/provesmoke
@@ -2,7 +2,6 @@
 use warnings FATAL => 'all';
 use strict;
 
-# $Id$
 use Test::More;
 
 use Getopt::Long;

--- a/resmoke.pl
+++ b/resmoke.pl
@@ -1,7 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.001';
 

--- a/runsmoke.pl
+++ b/runsmoke.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.002';
 

--- a/smokeperl.pl
+++ b/smokeperl.pl
@@ -5,7 +5,6 @@ eval 'exec /usr/bin/perl -w -S $0 ${1+"$@"}'
 use strict;
 $|=1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = Test::Smoke->VERSION;
 

--- a/smokeperl.pl
+++ b/smokeperl.pl
@@ -364,10 +364,6 @@ sub snapshot_name {
 
 L<README>, L<FAQ>, L<configsmoke.pl>, L<mktest.pl>, L<mkovz.pl>
 
-=head1 REVISION
-
-$Id$
-
 =head1 COPYRIGHT
 
 (c) 2002-2003, All rights reserved.

--- a/smokestatus.pl
+++ b/smokestatus.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.014';
 

--- a/sprove.pl
+++ b/sprove.pl
@@ -1,7 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.001';
 

--- a/synctree.pl
+++ b/synctree.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = '0.011';
 

--- a/sysinfo.pl
+++ b/sysinfo.pl
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 use vars qw( $VERSION );
 $VERSION = 0.001;
 

--- a/t/TestLib.pm
+++ b/t/TestLib.pm
@@ -1,7 +1,6 @@
 package TestLib;
 use strict;
 
-# $Id$
 use vars qw( $VERSION @EXPORT );
 $VERSION = '0.06';
 

--- a/t/buildcfg.t
+++ b/t/buildcfg.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Test::More tests => 81;
 my $verbose = 0;
 

--- a/t/cfgstuff.t
+++ b/t/cfgstuff.t
@@ -1,8 +1,6 @@
 #! perl -w
 use strict;
 
-# $Id$
-
 use File::Spec;
 
 use Test::More tests => 9;

--- a/t/get_cpus.t
+++ b/t/get_cpus.t
@@ -1,8 +1,6 @@
 #! perl -w
 use strict;
 
-# $Id$
-
 use Config;
 
 use Test::More tests => 3;

--- a/t/get_patch.t
+++ b/t/get_patch.t
@@ -1,8 +1,6 @@
 #! perl -w
 use strict;
 
-# $Id$
-
 use File::Spec;
 use File::Copy;
 

--- a/t/lpatches.t
+++ b/t/lpatches.t
@@ -1,8 +1,6 @@
 #! perl -w
 use strict;
 
-# $Id$
-
 use File::Spec::Functions;
 my $findbin;
 use File::Basename;

--- a/t/mailer.t
+++ b/t/mailer.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use File::Spec;
 my $findbin;
 use File::Basename;

--- a/t/parse_report.t
+++ b/t/parse_report.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Test::More;
 
 my @eg;

--- a/t/patcher.t
+++ b/t/patcher.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use File::Spec;
 my $findbin;
 use File::Basename;

--- a/t/patcher_forest.t
+++ b/t/patcher_forest.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use File::Spec::Functions;
 my $findbin;
 use File::Basename;

--- a/t/policy.t
+++ b/t/policy.t
@@ -2,7 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
 # This file checks to see if the new Test::Smoke::Policy object
 # does the same as the old way Merijn originaly wrote
 

--- a/t/regenstuff.t
+++ b/t/regenstuff.t
@@ -1,8 +1,6 @@
 #! perl -w
 use strict;
 
-# $Id$
-
 my $findbin;
 use File::Basename;
 BEGIN { $findbin = dirname $0; }

--- a/t/reporter.t
+++ b/t/reporter.t
@@ -2,8 +2,6 @@
 use strict;
 $| = 1;
 
-# $Id$
-
 use File::Spec::Functions;
 my $findbin;
 use File::Basename;

--- a/t/skip_config.t
+++ b/t/skip_config.t
@@ -2,8 +2,6 @@
 use strict;
 use Data::Dumper;
 
-# $Id$
-
 use Test::More;
 my @tests;
 BEGIN {

--- a/t/skip_filter.t
+++ b/t/skip_filter.t
@@ -1,8 +1,6 @@
 #! perl -w
 use strict;
 
-# $Id$
-
 # Add the test-lines in the '    EOT' here-document
 # First char should be 'P' for PASS (we don't want it)
 # and 'F' for FAIL (we _do_ want it)

--- a/t/smoked_config.t
+++ b/t/smoked_config.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use File::Spec;
 my $findbin;
 use File::Basename;

--- a/t/smoker.t
+++ b/t/smoker.t
@@ -2,7 +2,6 @@
 use strict;
 use Data::Dumper;
 
-# $Id$
 use File::Spec::Functions qw( :DEFAULT devnull abs2rel rel2abs );
 use Cwd;
 

--- a/t/syncer_copy.t
+++ b/t/syncer_copy.t
@@ -2,8 +2,6 @@
 use strict;
 use Data::Dumper;
 
-# $Id$
-
 my $findbin;
 use File::Basename;
 BEGIN { $findbin = dirname $0; }

--- a/t/syncer_ftp.t
+++ b/t/syncer_ftp.t
@@ -1,7 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
 ##### syncer_ftp.t
 #
 # Here we try to test the actual syncing process from a snapshot

--- a/t/syncer_ftpclient.t
+++ b/t/syncer_ftpclient.t
@@ -2,7 +2,6 @@
 use strict;
 use Data::Dumper;
 
-# $Id$
 ##### syncer_ftpclient.t
 #
 # Here we try to test the actual syncing process from ftp

--- a/t/syncer_link.t
+++ b/t/syncer_link.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Config;
 use File::Spec;
 use Cwd 'abs_path';

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Data::Dumper;
 use Cwd qw/cwd abs_path/;
 use File::Spec;

--- a/t/syncer_snap.t
+++ b/t/syncer_snap.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Data::Dumper;
 use Test::More tests => 3;
 

--- a/t/tree.t
+++ b/t/tree.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Data::Dumper;
 use File::Spec::Functions qw( :DEFAULT abs2rel rel2abs splitpath splitdir );
 use File::Find;

--- a/t/ts_config.t
+++ b/t/ts_config.t
@@ -1,8 +1,6 @@
 #! /usr/perl/perl -w
 use strict;
 
-# $Id$
-
 use FindBin;
 use Data::Dumper;
 use vars qw( $conf );

--- a/t/util_times.t
+++ b/t/util_times.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use Test::More;
 my $verbose = 0;
 

--- a/t/vms_rl.t
+++ b/t/vms_rl.t
@@ -1,8 +1,6 @@
 #! /usr/bin/perl -w
 use strict;
 
-# $Id$
-
 use File::Spec::Functions;
 use Cwd;
 

--- a/t/win32/makefile.mk
+++ b/t/win32/makefile.mk
@@ -1,8 +1,6 @@
 # This is a test makefile.mk for Configure_win32()
 # I need this to test all possible configuration stuff.
 #
-# $Id$
-#
 # These are not touched by default (Must be checked either way)
 INST_DRV	*= C:
 INST_TOP	*= $(INST_DRV)\perl

--- a/xt/10-smoker_basic.t
+++ b/xt/10-smoker_basic.t
@@ -2,7 +2,6 @@
 use strict;
 use FindBin;
 
-# $Id$
 use vars qw( @output ); @output = ();
 use Test::More tests => 6;
 

--- a/xt/20-smoker_fail.t
+++ b/xt/20-smoker_fail.t
@@ -3,8 +3,6 @@ use strict;
 use Data::Dumper;
 $| = 1;
 
-# $Id$
-
 my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
 use Cwd;

--- a/xt/30-smoker_mini.t
+++ b/xt/30-smoker_mini.t
@@ -3,8 +3,6 @@ use strict;
 use Data::Dumper;
 $| = 1;
 
-# $Id$
-
 my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
 use Cwd;

--- a/xt/40-smoker_ok.t
+++ b/xt/40-smoker_ok.t
@@ -3,8 +3,6 @@ use strict;
 use Data::Dumper;
 $| = 1;
 
-# $Id$
-
 my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
 use Cwd;

--- a/xt/50-smoker_smoke.t
+++ b/xt/50-smoker_smoke.t
@@ -3,8 +3,6 @@ use strict;
 use Data::Dumper;
 $| = 1;
 
-# $Id$
-
 my $verbose = exists $ENV{SMOKE_VERBOSE} ? $ENV{SMOKE_VERBOSE} : 0;
 
 use Cwd;

--- a/xt/SmokertestLib.pm
+++ b/xt/SmokertestLib.pm
@@ -1,7 +1,6 @@
 package SmokertestLib;
 use strict;
 
-# $Id$
 use vars qw( $VERSION @EXPORT );
 $VERSION = '0.004';
 

--- a/xt/perl/01test.c
+++ b/xt/perl/01test.c
@@ -1,7 +1,5 @@
 /* ********************************************************************** *
  *                                                                        *
- * $Id$                                                                   *
- *                                                                        *
  * 01test.c is a stupid program that can be compiled in three ways:       *
  *                                                                        *
  *   1) no defines (perl)                                                 *

--- a/xt/perl/win32/makefile.mk
+++ b/xt/perl/win32/makefile.mk
@@ -1,6 +1,5 @@
 # This file is a fixed makefile for dmake
 #      Makefile.PL
-#      $Id$
 #
 OPTIONS   =
 CCTYPE    = GCC

--- a/xt/sysinfo/macos.t
+++ b/xt/sysinfo/macos.t
@@ -2,8 +2,6 @@
 use warnings;
 use strict;
 
-# $Id$
-
 # We need at least 5.9.5 for the readpipe() override
 my $not595;
 BEGIN { eval qq/use 5.009005/; $not595 = $@ }


### PR DESCRIPTION
Since the project is now hosted using Git, the old Subversion `$Id` tags can be removed.  These changes implement this removal.  All tests pass.  Hope this helps!