### PR TITLE
Split rsync arguments that are combined into one string, such as the default '-az --delete'.

### DIFF
--- a/lib/Test/Smoke/Syncer/Rsync.pm
+++ b/lib/Test/Smoke/Syncer/Rsync.pm
@@ -72,7 +72,7 @@ sub sync {
         Carp::croak( "[rsync] Cannot chdir($self->{ddir}): $!" );
     };
     my $rsyncout = $rsync->run(
-        $self->{opts},
+        split( / /, $self->{opts} ),
         ($self->verbose ? "-v" : ""),
         $self->{source},
         File::Spec->curdir,

--- a/lib/Test/Smoke/Util/Execute.pm
+++ b/lib/Test/Smoke/Util/Execute.pm
@@ -125,7 +125,7 @@ Accessor that returns the arguments.
 
 sub arguments {
     my $self = shift;
-    if (@_) { $self->{arguments} = [@_]; }
+    if (@_) { $self->{arguments} = [ split / /, join(' ', @_) ]; }
 
     return $self->{arguments} ? @{ $self->{arguments} } : ()
 }

--- a/lib/Test/Smoke/Util/Execute.pm
+++ b/lib/Test/Smoke/Util/Execute.pm
@@ -125,7 +125,7 @@ Accessor that returns the arguments.
 
 sub arguments {
     my $self = shift;
-    if (@_) { $self->{arguments} = [ split / /, join(' ', @_) ]; }
+    if (@_) { $self->{arguments} = [@_]; }
 
     return $self->{arguments} ? @{ $self->{arguments} } : ()
 }

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -88,7 +88,7 @@ SKIP: { # Let's try to test the ->sync method
 
     my $cwd = abs_path();
     my $source = catdir($cwd, 't', 'ftppub', 'perl-current');
-    my $options = '-a';
+    my $options = '-az -v'; # make sure to include a space to check this gets split into 2 arguments
     my $ddir = catdir($cwd, 't', 'smoketest');
 
     my $rsync = Test::Smoke::Syncer->new(


### PR DESCRIPTION
The rsync test wasn't testing for additional arguments, and the default "-az --delete" was getting quoted by ::Execute and tried to run as: /usr/bin/rsync "-az --delete" foo bar

I changed the test to try "-az  -v" and fixed the rsync run() to split the string in opts. A more long-term solution (but way more work) would be to support arrayrefs for config opts.

Test failure before the fix:

```
rsync: -az -v: unknown option
rsync error: syntax or usage error (code 1) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-47/rsync/main.c(1333) [client=2.6.9]
Problem during rsync (1) at t/syncer_rsync.t line 526.
not ok 34 - ->sync returned a patch level
#   Failed test '->sync returned a patch level'
#   at t/syncer_rsync.t line 527.
#          got: undef
#     expected: '20000'
```