### PR TITLE
Rsync dot patch

### DIFF
--- a/configsmoke.pl
+++ b/configsmoke.pl
@@ -1254,7 +1254,7 @@ if ( $config{is56x} ) {
     $config{ $arg } = prompt_yn( $arg );
     if ( is_win32 && ! $config{ $arg } ) {
         print "*** WHOA THERE!!! ***\n";
-        print "\tYou should not try to use PERLIO=stdio on MSWin332!\n";
+        print "\tYou should not try to use PERLIO=stdio on MSWin32!\n";
     }
 }
 =item locale

--- a/lib/Test/Smoke/Syncer/Rsync.pm
+++ b/lib/Test/Smoke/Syncer/Rsync.pm
@@ -87,8 +87,8 @@ sub sync {
         Carp::carp( "Problem during rsync ($err)" );
     }
 
-    if (!-e catdir($self->{ddir}, '.patch') &&
-	 -d catdir($self->{ddir}, '.git')) {
+    if (!-e catfile($self->{ddir}, '.patch') &&
+	 -d catdir( $self->{ddir}, '.git'  )) {
         my $mk_dot_patch = Test::Smoke::Util::Execute->new(
             command => "$^X Porting/make_dot_patch.pl > .patch",
             verbose => $self->verbose,

--- a/lib/Test/Smoke/Syncer/Rsync.pm
+++ b/lib/Test/Smoke/Syncer/Rsync.pm
@@ -15,6 +15,7 @@ user-calls on this.
 =cut
 
 use Cwd;
+use File::Spec::Functions;
 use Test::Smoke::LogMixin;
 use Test::Smoke::Util::Execute;
 use Text::ParseWords;
@@ -84,6 +85,16 @@ sub sync {
     if (my $err = $rsync->exitcode ) {
         require Carp;
         Carp::carp( "Problem during rsync ($err)" );
+    }
+
+    if (!-e catdir($self->{ddir}, '.patch') &&
+	 -d catdir($self->{ddir}, '.git')) {
+        my $mk_dot_patch = Test::Smoke::Util::Execute->new(
+            command => "$^X Porting/make_dot_patch.pl > .patch",
+            verbose => $self->verbose,
+        );
+        my $perlout = $mk_dot_patch->run();
+        $self->log_debug($perlout);
     }
 
     chdir $cwd;


### PR DESCRIPTION
When cloning from a Git repository, obviously we know we have a
.git, so we can run Porting/make_dot_patch.pl. I have a slightly
odd setup where I have an external tool, Buildbot, starting off
my Test::Smoke runs. (This is nice because it lets me hit smoke-me
branches as well as blead and maint, and also balance load across
smokers.) However, that means I need Test::Smoke to use the
revision/branch that Buildbot has already checked out for it.
Unfortunately, Test::Smoke has no idea how to describe that
source tree once it's been copied, since there's no .patch file.
It's simply reported as '?????'.

I could just have Buildbot run Porting/make_dot_patch.pl before
calling Test::Smoke, but I also think it would be useful for
Test::Smoke to generate a .patch. This diff adds that function.
If there is a .git but no .patch in the working directory,
it runs Porting/make_dot_patch.pl before calling check_dot_patch.

If you agree, the same is true of the other Syncers. In fact,
it may even be safe to do this in Syncer::Base::check_dot_patch?
