### PR TITLE
Return arrayref when using git_version.h

### DIFF
--- a/lib/Test/Smoke/Util.pm
+++ b/lib/Test/Smoke/Util.pm
@@ -791,7 +791,7 @@ sub get_patch {
     if (open my $gvh, '<', $git_version_h) {
         while (my $line = <$gvh>) {
             if ($line =~ /^#define PERL_PATCHNUM "(.+)"$/) {
-                return $1;
+                return [$1];
             }
         }
         close $gvh;


### PR DESCRIPTION
get_patch() should return arrayrefs.

The get_patch() function can optionally look in the git_version.h file in the repo, but if it found one there it would return a string instead of an arrayref causing breakage similar to what is described below.

Can't use string ("v5.25.5-125-g7eff3d3") as an ARRAY ref while "strict refs" in use at /usr/local/libdata/perl5/site_perl/Test/Smoke/App/SmokePerl.pm line 48.
