### PR TITLE
RT #118488: Proper normalization for tests in cpan/, dist

### DIFF
--- a/lib/Test/Smoke/Smoker.pm
+++ b/lib/Test/Smoke/Smoker.pm
@@ -1021,7 +1021,7 @@ sub _parse_harness3_output {
     return $output;
 }
 
-=head2 $self->_trasnaform_testnames( @notok )
+=head2 $self->_transform_testnames( @notok )
 
 C<_transform_testnames()> takes a list of testnames, as found by
 C<TEST> (testname without C<.t> suffix followed by dots and a reason)
@@ -1056,7 +1056,7 @@ sub _normalize_testname {
     $test_name =~ s/\s+$//;
     $test_name =~ /\.t$/ or $test_name .= '.t';
     if ( $test_name !~ m|^\Q../| ) {
-        $test_name = $test_name =~ /^(?:ext|lib|t)\b/
+        $test_name = $test_name =~ /^(?:cpan|dist|ext|lib|t)\b/
             ? catfile( updir(), $test_name )
             : catfile( updir(), 't', $test_name );
     }


### PR DESCRIPTION
There is a function that is intended to transform from the "stripped"
test name (without leading ../ or trailing .t) to a usable relative
path. That function prepends '../t/' to tests, unless their name begins
with ext/ or lib/, in which case it prepends only '../'. This patch
adds cpan/ and dist/ to the list of special cases.

See http://perl5.test-smoke.org/report/50932 for successful test of this (compare to http://perl5.test-smoke.org/report/50929). This solves RT https://rt.cpan.org/Ticket/Display.html?id=118488
