### PR TITLE
Create 'perl-current' directory and repository anew each run.

### DIFF
--- a/lib/Test/Smoke/Syncer/Git.pm
+++ b/lib/Test/Smoke/Syncer/Git.pm
@@ -77,7 +77,7 @@ sub sync {
     $gitout = $gitbin->run(clean => '-dfx');
     $self->log_debug($gitout);
 
-    $gitout = $gitbin->run(fetch => ('--prune', $self->{gitorigin}));
+    $gitout = $gitbin->run(fetch => ('--prune', 'origin'));
     $self->log_debug($gitout);
 
     # We'll assume that 'blead' already exists, but we want it in sync with
@@ -85,7 +85,7 @@ sub sync {
     $gitout = $gitbin->run(checkout => 'blead');
     $self->log_debug($gitout);
 
-    $gitout = $gitbin->run(reset => ('--hard', "$self->{gitorigin}/blead"));
+    $gitout = $gitbin->run(reset => ('--hard', "origin/blead"));
     $self->log_debug($gitout);
 
     # get_git_branch() returns first line in file smokecurrent.gitbranch
@@ -101,7 +101,7 @@ sub sync {
         $gitout = $gitbin->run(branch => ('-D', $testingbranch));
         $self->log_debug($gitout);
 
-        $gitout = $gitbin->run(checkout => ('-b', $testingbranch, "$self->{gitorigin}/$testingbranch"));
+        $gitout = $gitbin->run(checkout => ('-b', $testingbranch, "origin/$testingbranch"));
         $self->log_debug($gitout);
     }
 

--- a/lib/Test/Smoke/Syncer/Git.pm
+++ b/lib/Test/Smoke/Syncer/Git.pm
@@ -17,7 +17,7 @@ use Cwd;
 use File::Spec::Functions;
 use Test::Smoke::LogMixin;
 use Test::Smoke::Util::Execute;
-use File::Path 2.12;
+use File::Path;
 
 =head2 Test::Smoke::Syncer::Git->new( %args )
 
@@ -113,7 +113,7 @@ sub sync {
     # up-to-date with origin, we'll simply create it de novo from that in
     # gitdir.  So the branch we want to test will already be set.
 
-    my $removed_count = File::Path::remove_tree($self->{ddir})
+    my $removed_count = File::Path::rmtree($self->{ddir})
         if (-d $self->{ddir});
 
     my $cloneout = $gitbin->run(


### PR DESCRIPTION
For the git synchronization problem described in:
https://rt.cpan.org/Ticket/Display.html?id=120008.

First, get the repository in 'git-perl' in sync with origin.  If smoking a
branch other than blead, remove any local branch by that name and create the
branch anew from origin so that we're getting the branch author's most recent
revisions.

Then, doing all that synching all over again in 'perl-current', simply remove
the perl-current directory entirely, and clone the now-up-to-date repo from
'git-perl' into it.  Then, proceed with smoke-testing as always.