### PR TITLE
Update location of Perl 5 repository

### DIFF
--- a/bin/configsmoke.pl
+++ b/bin/configsmoke.pl
@@ -415,7 +415,7 @@ my %opt = (
     gitorigin => {
         msg => "Git main repository?",
         alt => [ ],
-        dft => 'git://perl5.git.perl.org/perl.git',
+        dft => 'git://perl5.git.perl.org/perl5.git',
     },
     gitdir => {
         msg => "Directory for the local git repository?",

--- a/lib/Test/Smoke/App/Options.pm
+++ b/lib/Test/Smoke/App/Options.pm
@@ -421,7 +421,7 @@ sub gitorigin {
     return $opt->new(
         name => 'gitorigin',
         option => '=s',
-        default => 'git://perl5.git.perl.org/perl.git',
+        default => 'git://github.com/Perl/perl5.git',
         helptext => "The remote location of the git repository.",
     );
 }
@@ -701,7 +701,7 @@ sub rsyncsource {
     return $opt->new(
         name => 'source',
         option => '=s',
-        default => 'perl5.git.perl.org::perl-current',
+        default => 'github.com/Perl::perl-current',
         helptext => "The remote location of the rsync archive.",
     );
 }

--- a/lib/Test/Smoke/Syncer.pm
+++ b/lib/Test/Smoke/Syncer.pm
@@ -27,7 +27,7 @@ my %CONFIG = (
 # these settings have to do synctype==rsync
     df_rsync    => 'rsync', # you might want a path there
     df_opts     => '-az --delete',
-    df_source   => 'perl5.git.perl.org::perl-current',
+    df_source   => 'github.com/Perl::perl-current',
 
     rsync       => {
         allowed  => [qw(rsync source opts)],
@@ -37,7 +37,7 @@ my %CONFIG = (
 
 # these settings have to do with synctype==snapshot
     df_ftp      => 'Net::FTP',
-    df_server   => 'perl5.git.perl.org',
+    df_server   => 'github.com/Perl',
     df_sdir     => '/pub/apc/perl-current-snap',
     df_sfile    => '',
     df_snapext  => 'tar.gz',
@@ -46,7 +46,7 @@ my %CONFIG = (
         'Archive::Tar' : 'gzip -d -c %s | tar xf -' ),
 
     df_patchup  => 0,
-    df_pserver  => 'perl5.git.perl.org',
+    df_pserver  => 'github.com/Perl',
     df_pdir     => '/pub/apc/perl-current-diffs',
     df_ftpusr   => 'anonymous',
     df_ftppwd   => 'smokers@perl.org',
@@ -106,7 +106,7 @@ my %CONFIG = (
 
 # synctype: git
     df_gitbin        => 'git',
-    df_gitorigin     => 'git://perl5.git.perl.org/perl.git',
+    df_gitorigin     => 'git://github.com/Perl/perl5.git',
     df_gitdir        => undef,
     df_gitdfbranch   => 'blead',
     df_gitbranchfile => undef,

--- a/lib/Test/Smoke/Syncer/Git.pm
+++ b/lib/Test/Smoke/Syncer/Git.pm
@@ -36,7 +36,7 @@ Do the actual syncing.
 
 There are 2 repositories, they both need to be updated:
 
-The first (proxy) repository has the perl5.git.perl.org repository as its
+The first (proxy) repository has the github.com/Perl repository as its
 (origin) remote. The second repository is used to run the smoker from.
 
 For the proxy-repository we do:

--- a/lib/Test/Smoke/Syncer/Snapshot.pm
+++ b/lib/Test/Smoke/Syncer/Snapshot.pm
@@ -137,7 +137,7 @@ sub _fetch_snapshot_HTTP {
     my $self = shift;
 
     require LWP::Simple;
-    my $snap_name = $self->{server} eq 'http://perl5.git.perl.org'
+    my $snap_name = $self->{server} eq 'http://github.com/Perl'
         ? 'perl-current.tar.gz'
         : $self->{sfile};
 

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -14,7 +14,7 @@ use Test::Smoke::Util::FindHelpers 'whereis';
 
 my %df_rsync = (
     rsync => 'rsync',
-    source => 'perl5.git.perl.org::perl-current',
+    source => 'github.com/Perl::perl-current',
     opts   => '-az --delete',
     ddir   => File::Spec->canonpath(
         File::Spec->rel2abs('perl-current', abs_path(cwd()))


### PR DESCRIPTION
Note that I did not attempt to update all instances of the old
repository in bin/configsmoke.pl.

Needs careful code review.

For: https://rt.cpan.org/Ticket/Display.html?id=131711