### PR TITLE
feature/pass options to configure

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,10 +1,66 @@
-Changes on 2020-05-12 for repository at:
+Changes on 2020-05-13 for repository at:
+  Fetch URL: git@github.com:abeltje/Test-Smoke.git
+  Push  URL: git@github.com:abeltje/Test-Smoke.git
 
 Enjoy!
 
-1.76 2020-05-12T20:54:37+02:00 (531ef1e => Abe Timmerman)
- - (Abe Timmerman, 2 minutes ago) Autocommit for distribution Test::Smoke
+1.76_01 2020-05-13T15:51:25+02:00 (7b4e2ba => Abe Timmerman)
+ - (Abe Timmerman, 58 seconds ago) Autocommit for distribution Test::Smoke
+   1.76_01 (test)
+
+1.76 2020-05-12T20:54:37+02:00 (0801dd6 => Abe Timmerman)
+ - (Abe Timmerman, 19 hours ago) Autocommit for distribution Test::Smoke
    1.76 (minor)
+
+ - (H.Merijn Brand, 1 year, 1 month ago) Add support for -Uxx and -Dxx=y on
+   tssmokeperl.pl
+ -     When a smokescript smokes for two different compilers, it is likely
+   to use
+ -     something like
+ -     :
+ -     /pro/bin/perl tssmokeperl.pl --nofetch --nopatch \
+ -	   -c "$CFGNAME" $continue $* -Dcc=gcc > p59.log 2>&1
+ -     :
+ -     :
+ -     /pro/bin/perl tssmokeperl.pl --nofetch --nopatch \
+ -	   -c "$CFGNAME" $continue $* -Dcc=g++ > p59.log 2>&1
+ -     :
+ -     This change allows tssmokeperl.pl to accept -Dcc=gcc and/or -Ucc
+ -     and make it DWIM. Before this change, these command-line options
+ -     were silently ignored.
+ -     Only existing options can be (un)set
+
+ - (H.Merijn Brand - Tux, 1 year, 1 month ago) Moving -Dxx=... and -Uxx to
+   the correct spot
+
+ - (H.Merijn Brand - Tux, 1 year, 1 month ago) Also allow -A options
+
+ - (Abe Timmerman, 34 minutes ago) Add a Serialiser
+ -     This is a simple serialiser, I still have to hunt the rest of the
+   code
+ -     for uses of Data::Dumper type serialisations and see if I can change
+ -     them.
+
+ - (Abe Timmerman, 29 minutes ago) Add a '--pass_option' switch to the
+   runsmoke-applet
+ -     This (repeatable) option will let one pass extra options to
+   Configure
+ -     from the 'tsrunsmoke.pl' (and thus 'tssmokeperl.pl') commandline:
+ -     ~/coresmoke/ts/bin/tssmokeperl.pl -c "$CFGNAME" $* \
+ -	    --pass-option '-Dusesuperthreads' \
+ -	    -p '-Uusesuperfiles' > p59.log 2>&1
+ -     This is what Tux put in a commit message for a different solution of
+ -     his own request:
+ -     When a smokescript smokes for two different compilers, it is likely
+   to
+ -     use something like
+ -     /pro/bin/perl tssmokeperl.pl --nofetch --nopatch \
+ -	   -c "$CFGNAME" $continue $* -Dcc=gcc > p59.log 2>&1
+ -     /pro/bin/perl tssmokeperl.pl --nofetch --nopatch \
+ -	   -c "$CFGNAME" $continue $* -Dcc=g++ > p59.log 2>&1
+ -     This change allows tssmokeperl.pl to accept -Dcc=gcc and/or -Ucc
+ -     and make it DWIM. Before this change, these command-line options
+ -     were silently ignored.
 
 1.75 2020-03-01T12:41:23+01:00 (995b2f9 => Abe Timmerman)
  - (Abe Timmerman, 2 months ago) Autocommit for distribution Test::Smoke
@@ -236,8 +292,8 @@ Enjoy!
  - (Christian Walde, 1 year, 1 month ago) skip tests by modifying them in
    place instead of renaming them
 
- - (H.Merijn Brand - Tux, 1 year ago) Using Test::Smoke out of the box on
-   Win32
+ - (H.Merijn Brand - Tux, 1 year, 1 month ago) Using Test::Smoke out of the
+   box on Win32
  -     Thank you Christian for the time and effort
 
  - (H.Merijn Brand - Tux, 1 year ago) Correct minor typo in docs
@@ -450,8 +506,8 @@ Enjoy!
  - (abeltje, 3 years, 2 months ago) Autocommit for distribution Test::Smoke
    1.70_06 (same)
 
- - (H.Merijn Brand - Tux, 4 years ago) Replace Test::Smoke::SysInfo with
-   System::Info
+ - (H.Merijn Brand - Tux, 4 years, 1 month ago) Replace
+   Test::Smoke::SysInfo with System::Info
 
  - (H.Merijn Brand - Tux, 3 years, 2 months ago) Fix cpuinfo test results
    (based on System::Info)

--- a/MANIFEST
+++ b/MANIFEST
@@ -70,6 +70,7 @@ lib/Test/Smoke/Util.pm
 lib/Test/Smoke/Util/Execute.pm
 lib/Test/Smoke/Util/FindHelpers.pm
 lib/Test/Smoke/Util/LoadAJSON.pm
+lib/Test/Smoke/Util/Serialise.pm
 lib/Test/Smoke/Util/Win32ErrorMode.pm
 lib/Test/Smoke/maint_dfconfig
 lib/Test/Smoke/perl58x.cfg
@@ -84,6 +85,7 @@ t/10-fallback.t
 t/11-no_fallback.t
 t/15-factory-json.t
 t/20-logger.t
+t/25-util-serialise.t
 t/TestLib.pm
 t/app/000-appobjects.t
 t/app/010-appoptions.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -121,6 +121,7 @@ else {
 my %TEST_REQUIRES = (
     'Test::More'       => 0.88,
     'Test::NoWarnings' => 0,
+    'Test::Fatal'      => 0,
     'HTTP::Daemon'     => 0,
     'HTTP::Message'    => 0,
 );
@@ -175,7 +176,7 @@ $mmver > 6.46 and $wm{META_ADD} = {
         homepage   => "http://perl5.test-smoke.org/",
         repository => {
             type   => "git",
-            url    => "git://github.com/abeltje/Test-Smoke.git",
+            url    => "git\@github.com:abeltje/Test-Smoke.git",
             web    => "https://github.com/abeltje/Test-Smoke",
         },
         x_IRC      => "irc://irc.perl.org/#smoke",

--- a/lib/Test/Smoke.pm
+++ b/lib/Test/Smoke.pm
@@ -2,7 +2,7 @@ package Test::Smoke;
 use strict;
 
 use vars qw($VERSION $conf @EXPORT);
-$VERSION  = '1.76';
+$VERSION  = '1.76_01';
 
 use base 'Exporter';
 @EXPORT  = qw( $conf &read_config &run_smoke );

--- a/lib/Test/Smoke/App/AppOption.pm
+++ b/lib/Test/Smoke/App/AppOption.pm
@@ -55,7 +55,7 @@ croak()s when:
 
 =item B<name not set>
 
-=item B<allow is not undef or an ArrayRef>
+=item B<allow is not undef or ref($allow) is Regexp, CODE or ARRAY>
 
 =back
 

--- a/lib/Test/Smoke/App/Base.pm
+++ b/lib/Test/Smoke/App/Base.pm
@@ -373,23 +373,7 @@ sub _post_process_options {
             %{$self->cli_options},
         }
     );
-
     my @errors;
-    # Now overrule from commandline
-    my $fo = $self->{_final_options};
-    foreach my $opt (grep m/^-(D\w+=.*|-U\w+)$/ => @{$self->{_ARGV}}) {
-	if ($opt =~ m/^-U(\w+)/) {
-	    exists $fo->{$1}
-		?  $fo->{$1} = ""
-		: push @errors, "Cannot unset non-existent option $1";
-	    next;
-	}
-	$opt =~ m/^-D(\w+)=(.*)/;
-	exists $fo->{$1}
-	    ?  $fo->{$1} = $2
-	    : push @errors, "Cannot set non-existent option $1";
-    }
-
     my %check_options = $self->options;
     for my $opt (keys %check_options) {
         my $oo = $self->_find_option($opt);

--- a/lib/Test/Smoke/App/Base.pm
+++ b/lib/Test/Smoke/App/Base.pm
@@ -12,6 +12,7 @@ use Getopt::Long qw/:config pass_through/;
 use Test::Smoke::App::AppOption;
 use Test::Smoke::App::AppOptionCollection;
 use Test::Smoke::LogMixin;
+use Test::Smoke::Util::Serialise qw/serialise/;
 
 =head1 NAME
 
@@ -352,6 +353,7 @@ sub _get_options {
 
     %{$self->{_cli_options}} = %{$self->opt_collection->options_for_cli};
     @{$self->{_ARGV}} = @ARGV;
+    Getopt::Long::Configure('no_ignore_case');
     GetOptions(
         $self->cli_options,
         @{ $self->opt_collection->options_list },
@@ -402,10 +404,17 @@ sub _post_process_options {
         for my $opt (sort keys %options) {
             printf "  %-20s| %s\n",
                 $opt,
-                $self->option($opt) || '?';
+                $self->_show_option_value($opt) || '?';
         }
         exit(0);
     }
+}
+
+sub _show_option_value {
+    my $self =  shift;
+    my ($option_name) = @_;
+
+    return serialise( $self->option($option_name) );
 }
 
 sub _obtain_config_file {

--- a/lib/Test/Smoke/App/Base.pm
+++ b/lib/Test/Smoke/App/Base.pm
@@ -373,7 +373,23 @@ sub _post_process_options {
             %{$self->cli_options},
         }
     );
+
     my @errors;
+    # Now overrule from commandline
+    my $fo = $self->{_final_options};
+    foreach my $opt (grep m/^-(D\w+=.*|-U\w+)$/ => @{$self->{_ARGV}}) {
+	if ($opt =~ m/^-U(\w+)/) {
+	    exists $fo->{$1}
+		?  $fo->{$1} = ""
+		: push @errors, "Cannot unset non-existent option $1";
+	    next;
+	}
+	$opt =~ m/^-D(\w+)=(.*)/;
+	exists $fo->{$1}
+	    ?  $fo->{$1} = $2
+	    : push @errors, "Cannot set non-existent option $1";
+    }
+
     my %check_options = $self->options;
     for my $opt (keys %check_options) {
         my $oo = $self->_find_option($opt);

--- a/lib/Test/Smoke/App/Options.pm
+++ b/lib/Test/Smoke/App/Options.pm
@@ -195,6 +195,7 @@ sub runsmoke_config { # runsmoke.pl
             w32args(),
             w32cc(),
             w32make(),
+            pass_option(),
         ],
     );
 }
@@ -898,7 +899,7 @@ sub w32args {
 sub w32cc {
     return $opt->new(
         name => 'w32cc',
-        opt => '=s',
+        option => '=s',
         helptext => "The compiler on MSWin32.",
     );
 }
@@ -906,9 +907,26 @@ sub w32cc {
 sub w32make {
     return $opt->new(
         name => 'w32make',
-        opt => '=s',
+        option => '=s',
         default => 'dmake',
         helptext => "The make program on MSWin32.",
+    );
+}
+
+sub pass_option {
+    return $opt->new(
+        name => 'pass_option',
+        option => 'pass-option|p=s@',
+        default => [],
+        allow => sub {
+            my ($list) = @_;
+            return unless ref($list) eq 'ARRAY';
+            for my $to_pass (@$list) {
+                return unless $to_pass =~ m{^ - [DUA] .+ $}x;
+            }
+            return 1;
+        },
+        helptext => 'Pass these options to Configure.',
     );
 }
 

--- a/lib/Test/Smoke/App/RunSmoke.pm
+++ b/lib/Test/Smoke/App/RunSmoke.pm
@@ -65,7 +65,7 @@ sub run {
         Test::Smoke::Util::Win32ErrorMode::lower_error_settings();
     }
 
-   $self->run_smoke(grep m/^-(D\w+=.*|-U\w+)$/ => @{$self->{_ARGV}});
+   $self->run_smoke(grep m/^-(D\w+=.*|-U\w+|-A\w.+)$/ => @{$self->{_ARGV}});
    chdir $cwd;
 }
 

--- a/lib/Test/Smoke/App/RunSmoke.pm
+++ b/lib/Test/Smoke/App/RunSmoke.pm
@@ -65,7 +65,7 @@ sub run {
         Test::Smoke::Util::Win32ErrorMode::lower_error_settings();
     }
 
-   $self->run_smoke();
+   $self->run_smoke(grep m/^-(D\w+=.*|-U\w+)$/ => @{$self->{_ARGV}});
    chdir $cwd;
 }
 

--- a/lib/Test/Smoke/App/RunSmoke.pm
+++ b/lib/Test/Smoke/App/RunSmoke.pm
@@ -65,7 +65,7 @@ sub run {
         Test::Smoke::Util::Win32ErrorMode::lower_error_settings();
     }
 
-   $self->run_smoke(grep m/^-(D\w+=.*|-U\w+|-A\w.+)$/ => @{$self->{_ARGV}});
+   $self->run_smoke(@{ $self->option('pass_option') });
    chdir $cwd;
 }
 

--- a/lib/Test/Smoke/Util/Serialise.pm
+++ b/lib/Test/Smoke/Util/Serialise.pm
@@ -1,0 +1,113 @@
+package Test::Smoke::Util::Serialise;
+use warnings;
+use strict;
+
+use Exporter 'import';
+our @EXPORT_OK = qw( serialise );
+
+=head1 NAME
+
+Test::Smoke::Util::Serialise - Serialise (stringify) values, a bit like
+L<Data::Dumper>.
+
+=head1 SYNOPSIS
+
+    use Test::Smoke::Util::Serialise 'serialise';
+
+    my $value = [ qw( one two three ) ];
+    printf "Looks like: '%s'\n", serialise($value);
+    # Looks like: '[one, two, three]'\n
+
+=head1 DESCRIPTION
+
+Mostly looks like L<Data::Dumper::Dumper>, with C<$Indent = 0>, C<$Sortkeys = 1>
+and C<$Terse = 1>.
+
+=head2 serialise($to_serialise)
+
+Make a string representation of the argument passed.
+
+Arrays are represented with enclosing square brackets
+
+Hashes are represented with enclosing curly braces, where all te Key-Value-pairs
+have enclosing parenthesis with a C<< => >> (fat comma) in-between.
+
+    {(one => two), (three => [four, five]), (six => {(seven => eight)}, (nine => \ten))}
+
+=head3 Arguments
+
+Positional:
+
+=over
+
+=item 1. B<$to_serialise>
+
+=back
+
+=head3 Responses
+
+A string representation of the value passed.
+
+=cut
+
+sub serialise {
+    my ($to_serialise) = @_;
+
+    GIVEN {
+        local $_ = ref($to_serialise);
+
+        m{^ SCALAR $}x and do {
+            return "\\" . serialise($$to_serialise);
+        };
+        m{^ ARRAY $}x and do {
+            return sprintf(
+                "[%s]",
+                join(", ", map { serialise($_) } @$to_serialise)
+            );
+        };
+        m{^ HASH $}x and do {
+            return sprintf(
+                "{%s}",
+                join(
+                    ", ",
+                    map {
+                        sprintf("(%s => %s)", $_, serialise($to_serialise->{$_}))
+                    } sort keys %$to_serialise
+                )
+            );
+        };
+        # default, trust stringify
+        do {
+            return defined($to_serialise) ? "$to_serialise" : undef;
+        };
+    }
+}
+
+1;
+
+=head1 COPYRIGHT
+
+(c) 2020, Abe Timmerman <abeltje@cpan.org> All rights reserved.
+
+With contributions from Jarkko Hietaniemi, Merijn Brand, Campo
+Weijerman, Alan Burlison, Allen Smith, Alain Barbet, Dominic Dunlop,
+Rich Rauenzahn, David Cantrell.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+See:
+
+=over 4
+
+=item * L<http://www.perl.com/perl/misc/Artistic.html>
+
+=item * L<http://www.gnu.org/copyleft/gpl.html>
+
+=back
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+=cut

--- a/t/25-util-serialise.t
+++ b/t/25-util-serialise.t
@@ -1,0 +1,49 @@
+#! perl -w
+use strict;
+use Test::More;
+use Test::NoWarnings ();
+use Test::Fatal qw( lives_ok );
+
+use Test::Smoke::Util::Serialise;
+
+Test::Smoke::Util::Serialise->import( 'serialise' );
+
+my $string;
+lives_ok(
+    sub { $string = serialise(\1); }, 
+    "'serialise()' was imported"
+);
+is($string, "\\1", "serialise() worked");
+
+my $four = qr{^ four $}x;
+my $origin = {one => 'two', three => $four, five => ['six', 'seven']};
+is(
+    serialise($origin),
+    "{(five => [six, seven]), (one => two), (three => $four)}", # sort keys
+    "basic serialise()"
+) or diag(explain($origin));
+
+my $object1 = bless {}, 'CannotSerialise';
+like(
+    serialise($object1),
+    qr{ CannotSerialise = HASH \(0x [0-9a-f]+ \) $}x,
+    "serialise() object1"
+);
+
+my $object2 = bless {}, 'CanSerialise';
+is(
+    serialise($object2),
+    "I am a serial: 42",
+    "serialise() object2"
+);
+
+Test::NoWarnings::had_no_warnings();
+$Test::NoWarnings::do_end_test = 0;
+done_testing();
+
+package CanSerialise;
+use overload
+    '""' => sub { 'I am a serial: 42' },
+    fallback => 1,
+;
+1;

--- a/t/app/110-runsmoke.t
+++ b/t/app/110-runsmoke.t
@@ -91,6 +91,9 @@ Test::Smoke::App::RunSmoke::run_smoke...
         '--sync_type' => 'copy',
         '--cdir'      => $cdir,
         '--verbose'   => 1,
+        # also test the new --pass_option switch
+        '-p'          => '-Dusesuperthreads',
+        '-p'          => '-Uusesuperfiles',
     );
     my $app = Test::Smoke::App::RunSmoke->new(
         Test::Smoke::App::Options->runsmoke_config()
@@ -111,7 +114,11 @@ Test::Smoke::App::RunSmoke::run_smoke...
     local *Test::Smoke::Smoker::ttylog = sub { };
     local *Test::Smoke::Smoker::tty    = sub { };
     local *Test::Smoke::Smoker::log    = sub { };
-    local *Test::Smoke::Smoker::smoke = sub { };
+    local *Test::Smoke::Smoker::smoke = sub {
+        my $self = shift;
+        my ($bldcfg) = @_;
+        ok($bldcfg->has_arg(qw( -Dusesuperthreads -Uusesuperfiles )), "Found extra arguments");
+    };
 
     # Replace this version of Test::Harness with a beta-version RT-118879
     my $thp = catfile(catdir($ddir, 'cpan', 'Test-Harness', 'lib', 'Test'), 'Harness.pm');

--- a/xt/03-pod-coverage.t
+++ b/xt/03-pod-coverage.t
@@ -93,3 +93,4 @@ vmsmake
 w32args
 w32cc
 w32make
+pass_option


### PR DESCRIPTION
Feature request by @Tux, he wants to pass Configure options (`-Dxxx`, `-Uxxx` and `-Axxx`) from the command-line when calling `tssmokeperl.pl`. This pull request implements a solution for that request.