### PR TITLE
Make git use a different default branch name to prevent warnings

### DIFF
--- a/t/syncer_git.t
+++ b/t/syncer_git.t
@@ -27,11 +27,12 @@ my $tmpdir = tempdir(CLEANUP => ($ENV{SMOKE_DEBUG} ? 0 : 1));
 my $upstream = catdir($tmpdir, 'tsgit');
 my $playground = catdir($tmpdir, 'playground');
 my $branchfile = catfile($tmpdir, 'default.gitbranch');
+my $branchname = 'main'; # instead of "master" to prevent warnings
 
 {
     pass("Git version $gitversion");
     # Set up a basic git repository
-    $git->run(init => $upstream);
+    $git->run(init => '-b', $branchname, $upstream);
     is($git->exitcode, 0, "git init $upstream");
 
     mkpath("$upstream/Porting");
@@ -52,7 +53,7 @@ print <>;
     $git->run(commit => '-m', "'We need a first file committed'", '2>&1');
 
     chdir catdir(updir, updir);
-    put_file("master\n" => $branchfile);
+    put_file("$branchname\n" => $branchfile);
     mkpath($playground);
     {
         my $syncer = Test::Smoke::Syncer->new(
@@ -74,7 +75,7 @@ print <>;
         );
         is(
             $syncer->get_git_branch,
-            'master',
+            $branchname,
             "  from branchfile: chomp()ed value"
         );
 

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -77,11 +77,12 @@ SKIP: {
     my $gitbin = whereis('git');
     skip("No git found :(", 10) if ! $gitbin;
 
+    my $branchname = 'main'; # instead of "master" to prevent warnings
     my $cwd = abs_path();
     # Set up a basic git repository
     my $git = Test::Smoke::Util::Execute->new(command => $gitbin);
     my $repopath = 't/tsgit';
-    $git->run(init => $repopath);
+    $git->run(init => "-b", $branchname, $repopath);
     is($git->exitcode, 0, "git init $repopath");
 
     mkpath("$repopath/Porting");


### PR DESCRIPTION
ok 1 - Git version 2.37.2
[2022-08-16 08:48:10+0200] qx[/usr/bin/git init /tmp/B5mqfRwdHq/tsgit]
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>