### PR TITLE
Include custom hostname in smoke report

### DIFF
--- a/lib/Test/Smoke/Reporter.pm
+++ b/lib/Test/Smoke/Reporter.pm
@@ -1137,7 +1137,7 @@ sub preamble {
 
     my $cpu = $si->cpu;
 
-    my $this_host = $si->host;
+    my $this_host = $self->{hostname} || $si->host;
     my $time_msg  = time_in_hhmm( $self->{_rpt}{secs} );
     my $savg_msg  = time_in_hhmm( $self->{_rpt}{avg}  );
 

--- a/t/report-hostname.t
+++ b/t/report-hostname.t
@@ -1,0 +1,32 @@
+#! perl -w
+use strict;
+
+use Test::More;
+
+use Test::Smoke::Reporter;
+
+{
+    no warnings 'redefine';
+    local *Test::Smoke::Reporter::read_parse = sub { return $_[0] };
+    local *Test::Smoke::Reporter::get_smoked_Config = sub {
+        return (version => 1234)
+    };
+    local *Test::Smoke::Reporter::ccinfo = sub { return 'mycc version 42' };
+    my $r = Test::Smoke::Reporter->new(
+        ddir        => 't',
+        hostname    => 'my.custom.hostname',
+    );
+    isa_ok($r, 'Test::Smoke::Reporter');
+    $r->{_rpt} = { secs => 42, avg => 21, patchlevel => 987 };
+
+
+    my $preamble = $r->preamble();
+
+    like(
+        $preamble,
+        qr/^\Qmy.custom.hostname\E:/mx,
+        "  custom hostname in preamble",
+    );
+}
+
+done_testing();


### PR DESCRIPTION
In commit 5920e4cbcef17d7b00206d52dddd5b8ba33aafea

	Author: abeltje <abeltje@test-smoke.org>
	Date:   Fri Apr 20 22:38:11 2018 +0200

	    Solve https://github.com/abeltje/Test-Smoke/pull/37

	    I don't like using ENVironment vars for legitimate settings in the
	    software, so I'd rather use the configfile for that.
	    Add a question in  configsmoke.pl

The option was added to set a custom hostname in the configfile.
In that commit the custom hostname is used when sending the report to
the smokedb (that is: in `Test::Smoke::Reporter::smokedb_data`).

But the hostname is also used in the preamble of the report and that
code was left unchanged so the real hostname still leaked in the report.

Fix this and (also) use the custom hostname in the `preamble` function.
(+ add a test for it, test file is based on t/report-usernote.t)

(Note: commit 5920e4c was based on a PR and in the original commit
       the preamble function was also updated. That part of the
       change got lost when converting it to a config option.)