### PR TITLE
Use `done_testing()` in t/report-usernote.t

### DIFF
--- a/t/report-usernote.t
+++ b/t/report-usernote.t
@@ -1,7 +1,7 @@
 #! perl -w
 use strict;
 
-use Test::More 'no_plan';
+use Test::More;
 
 use Test::Smoke::Reporter;
 
@@ -47,4 +47,4 @@ use Test::Smoke::Reporter;
     );
 }
 
-# done_testing();
+done_testing();


### PR DESCRIPTION
The test file was added in commit 792da5b7176f3141f5c45e54e16a4fa1d0b34230

	Author: Abe Timmerman <abeltje@diefenbaker.local>
	Date:   Mon Apr 15 00:27:00 2013 +0200

	    Implement variable position for the user_note:
	      - un_position == 'top' => at the start of the report
	      - un_position == <!top> => at the end of the report

My guess: `done_testing()` was commented support older perls (with an
          oder versions of  Test::More which lacked support for it).

Today: plenty of other files in the repo are using `done_testing()` so
there is no reason why t/report-usernote.t shouldn't be using it.