### PR TITLE
Turn on autoflush for STDERR

### DIFF
--- a/bin/W32Configure.pl
+++ b/bin/W32Configure.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 # BEGIN { die "You must be on MSWin32 for this!\n" unless $^O eq 'MSWin32' }
 

--- a/bin/archiverpt.pl
+++ b/bin/archiverpt.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/mailrpt.pl
+++ b/bin/mailrpt.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/patchtree.pl
+++ b/bin/patchtree.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/runsmoke.pl
+++ b/bin/runsmoke.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/sendrpt.pl
+++ b/bin/sendrpt.pl
@@ -1,5 +1,8 @@
 #!/usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 use vars qw( $VERSION );

--- a/bin/smokeperl.pl
+++ b/bin/smokeperl.pl
@@ -3,6 +3,9 @@
 eval 'exec /usr/bin/perl -w -S $0 ${1+"$@"}'
     if 0; # not running under some shell
 use strict;
+select(STDERR);
+$|=1;
+select(STDOUT);
 $|=1;
 
 # $Id$

--- a/bin/smokestatus.pl
+++ b/bin/smokestatus.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/synctree.pl
+++ b/bin/synctree.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/sysinfo.pl
+++ b/bin/sysinfo.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$| = 1;
+select(STDOUT);
 $| = 1;
 
 # $Id$

--- a/bin/tsarchive.pl
+++ b/bin/tsarchive.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$|++;
+select(STDOUT);
 $|++;
 
 use File::Spec::Functions;

--- a/bin/tsreport.pl
+++ b/bin/tsreport.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$|++;
+select(STDOUT);
 $|++;
 
 use File::Spec::Functions;

--- a/bin/tsrunsmoke.pl
+++ b/bin/tsrunsmoke.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$|++;
+select(STDOUT);
 $|++;
 
 use File::Spec::Functions;

--- a/bin/tssendrpt.pl
+++ b/bin/tssendrpt.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$|++;
+select(STDOUT);
 $|++;
 
 use File::Spec::Functions;

--- a/bin/tssmokeperl.pl
+++ b/bin/tssmokeperl.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$|++;
+select(STDOUT);
 $|++;
 
 use File::Spec::Functions;

--- a/bin/tssynctree.pl
+++ b/bin/tssynctree.pl
@@ -1,5 +1,8 @@
 #! /usr/bin/perl -w
 use strict;
+select(STDERR);
+$|++;
+select(STDOUT);
 $|++;
 
 use File::Spec::Functions;


### PR DESCRIPTION
On Windows there *appears* to be some buffering for STDERR.
I noticed this when troubleshooting/testing for issue #54: at some
point the STDERR output got split and was mixed between (later)
STDOUT output. [There is a sample log file in the ticket.]

What appears to fix it is to turn on autoflush for STDERR. Then the
logfile contains the expected output (when `print STDERR $err` is used).

So just to be avoid the issue in the future: do an explicit autoflush
of STDERR in the scripts.

(I do have some changes in mind where there could be output to both
 STDOUT and STDERR)