### PR TITLE
Fix `git init` for older git versions

### DIFF
--- a/t/syncer_git.t
+++ b/t/syncer_git.t
@@ -29,11 +29,13 @@ my $playground = catdir($tmpdir, 'playground');
 my $branchfile = catfile($tmpdir, 'default.gitbranch');
 my $branchname = 'main'; # instead of "master" to prevent warnings
 
-{
+SKIP: {
     pass("Git version $gitversion");
     # Set up a basic git repository
     $git->run(init => '-b', $branchname, $upstream);
-    is($git->exitcode, 0, "git init $upstream");
+    unless (is($git->exitcode, 0, "git init $upstream")) {
+        skip "git init failed! The tests require an empty/different repo";
+    }
 
     mkpath("$upstream/Porting");
     chdir $upstream;

--- a/t/syncer_git.t
+++ b/t/syncer_git.t
@@ -27,12 +27,12 @@ my $tmpdir = tempdir(CLEANUP => ($ENV{SMOKE_DEBUG} ? 0 : 1));
 my $upstream = catdir($tmpdir, 'tsgit');
 my $playground = catdir($tmpdir, 'playground');
 my $branchfile = catfile($tmpdir, 'default.gitbranch');
-my $branchname = 'main'; # instead of "master" to prevent warnings
+my $branchname = 'master'; # for compatibility with old and new git version
 
 SKIP: {
     pass("Git version $gitversion");
     # Set up a basic git repository
-    $git->run(init => '-b', $branchname, $upstream);
+    $git->run('-c' => "init.defaultBranch=$branchname", init => '-q',$upstream);
     unless (is($git->exitcode, 0, "git init $upstream")) {
         skip "git init failed! The tests require an empty/different repo";
     }

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -83,7 +83,9 @@ SKIP: {
     my $git = Test::Smoke::Util::Execute->new(command => $gitbin);
     my $repopath = 't/tsgit';
     $git->run(init => "-b", $branchname, $repopath);
-    is($git->exitcode, 0, "git init $repopath");
+    unless (is($git->exitcode, 0, "git init $repopath")) {
+        skip "git init failed! The tests require an empty/different repo";
+    }
 
     mkpath("$repopath/Porting");
     chdir $repopath;

--- a/t/syncer_rsync.t
+++ b/t/syncer_rsync.t
@@ -77,12 +77,12 @@ SKIP: {
     my $gitbin = whereis('git');
     skip("No git found :(", 10) if ! $gitbin;
 
-    my $branchname = 'main'; # instead of "master" to prevent warnings
+    my $branchname = 'master'; # for compatibility with old and new git version
     my $cwd = abs_path();
     # Set up a basic git repository
     my $git = Test::Smoke::Util::Execute->new(command => $gitbin);
     my $repopath = 't/tsgit';
-    $git->run(init => "-b", $branchname, $repopath);
+    $git->run('-c' => "init.defaultBranch=$branchname", init => "-q", $repopath);
     unless (is($git->exitcode, 0, "git init $repopath")) {
         skip "git init failed! The tests require an empty/different repo";
     }


### PR DESCRIPTION
The tests were failing because `git init -b ....` doesn't work on older git versions.

(In addition to that: due to `git init` failing the tests were adding commits to the Test-Smoke repository.. - so fix that too)
