### PR TITLE
Cache `$daemon->sockhost` in t/poster-post.t

### DIFF
--- a/t/poster-post.t
+++ b/t/poster-post.t
@@ -32,12 +32,14 @@ my ($pid, $daemon, $url);
 
 my $timeout = 60;
 my $jsnfile = 'testsuite.jsn';
+my $sockhost;
 {
     $daemon = HTTP::Daemon->new() || die "Could not initialize a Daemon";
     $url = URI->new($daemon->url);
+    $sockhost = $daemon->sockhost;
     note(
         "HTTP::Daemon ($HTTP::Daemon::VERSION): ",
-        $daemon->sockhost eq '::' ? "IPv6" : "IPv4",
+        $sockhost eq '::' ? "IPv6" : "IPv4",
         " (" , $url->host, ")"
     );
 
@@ -45,7 +47,7 @@ my $jsnfile = 'testsuite.jsn';
     # IPv6 doesn't work, so force IPv4 localhost HTTP::Daemon < 6.05
     if ($HTTP::Daemon::VERSION <= 6.07) {
         # Check $daemon->sockhost for either '0.0.0.0' (ipv4) or '::' (ipv6)
-        if ($daemon->sockhost eq '::') {
+        if ($sockhost eq '::') {
             $url->host('[::1]');
         }
         else {
@@ -146,7 +148,7 @@ SKIP: {
 SKIP: {
     skip("Could not load HTTP::Tiny", 3) if ! has_module('HTTP::Tiny');
     skip("HTTP::Tiny too old $HTTP::Tiny::VERSION (IPv6 support >= 0.042)", 3)
-        if    $daemon->sockhost eq '::'
+        if    $sockhost eq '::'
           and version->parse($HTTP::Tiny::VERSION) < version->parse("0.042");
 
     my $poster = Test::Smoke::Poster->new(


### PR DESCRIPTION
On my Windows 10 system 't/poster-post.t' was stuck.
Debugging showed that this *apparently* happened when it tried to get
the value of `$daemon->sockhost` for the test with 'HTTP::Tiny'.

Earlier calls for `$daemon->sockhost` (for the curl test) did succeed
and did behave as expected...

Sample output of a run that was stuck:

	# HTTP::Daemon (6.12): IPv6 (::1)
	# Temporary daemon at: http://[::1]:57965/
	ok 1 - An object of class 'Test::Smoke::Poster::LWP_UserAgent' isa 'Test::Smoke::Poster::LWP_UserAgent'
	ok 2 - write_json
	[2022-08-18 16:47:15Z] Posting to http://[::1]:57965/report via LWP::UserAgent.
	[2022-08-18 16:47:15Z] Reading from (C:\Perl\Test-Smoke\t\testsuite.jsn)
	[2022-08-18 16:47:15Z] Report data: {"sysinfo":"MSWin32"}
	[2022-08-18 16:47:15Z] [CoreSmokeDB] {"id":42}
	ok 3 - Got id (LWP::Useragent: http://[::1]:57965/report)
	ok 4 - An object of class 'Test::Smoke::Poster::Curl' isa 'Test::Smoke::Poster::Curl'
	ok 5 - write_json
	[2022-08-18 16:47:15Z] Posting to "http://[::1]:57965/report" via curl.
	[2022-08-18 16:47:15Z] Reading from (C:\Perl\Test-Smoke\t\testsuite.jsn)
	[2022-08-18 16:47:15Z] Report data: {"sysinfo":"MSWin32"}
	[2022-08-18 16:47:15Z] In pwd(C:/Perl/Test-Smoke) running:
	[2022-08-18 16:47:15Z] qx[C:\Windows\system32\curl.EXE --globoff -A "Test::Smoke/1.79_01 (Test::Smoke::Poster::Curl)" -d json=%7B%22sysinfo%22%3A%22MSWin32%22%7D "http://[::1]:57965/report"]
	  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
	                                 Dload  Upload   Total   Spent    Left  Speed
	100    49  100     9  100    40    522   2322 --:--:-- --:--:-- --:--:--  3062
	[2022-08-18 16:47:15Z] [CoreSmokeDB] {"id":42}
	ok 6 - Got id (curl: http://[::1]:57965/report)

And then it kept on waiting..
Caching the value of `$daemon->sockhost` appears to fix it..
(I've got no idea why tho)

With this patch applied and re-running the test it continues:

	ok 7 - An object of class 'Test::Smoke::Poster::HTTP_Tiny' isa 'Test::Smoke::Poster::HTTP_Tiny'
	ok 8 - write_json
	[2022-08-18 16:56:15Z] Posting to http://[::1]:57990/report via HTTP::Tiny.
	[2022-08-18 16:56:15Z] Reading from (C:\Perl\Test-Smoke\t\testsuite.jsn)
	[2022-08-18 16:56:15Z] Report data: {"sysinfo":"MSWin32"}
	[2022-08-18 16:56:15Z] [CoreSmokeDB] {"id":42}
	ok 9 - Got id (HTTP::Tiny: http://[::1]:57990/report
	ok 10 - no warnings
	1..10