### PR TITLE
Add a target to the makefile to run the xt/ tests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -190,18 +190,6 @@ WriteMakefile(
     %install
 );
 
-#sub MY::libscan {
-#    my( $self, $path ) = @_;
-#    my @nopaths = qw( .svn t private investigate );
-#    my $patt = join '|', map {
-#        /^\w/ and $_ = "\\b$_";
-#        /\w$/ and $_ = "$_\\b";
-#        $_;
-#    } @nopaths;
-#
-#    return $path =~ m:$patt: ? "" : $path;
-#}
-
 sub dir_prompt {
 
     GETDIR: {
@@ -226,3 +214,23 @@ sub dir_prompt {
         return $dir;
     }
 }
+
+package MY;
+
+sub test {
+    my $orig = shift->SUPER::test(@_);
+
+    $orig .= <<"EOM";
+
+XTEST_FILES = xt/*.t
+xtest ::
+ifeq (\$(TEST_VERBOSE), 1)
+\tprove -wlv \$(XTEST_FILES)
+else
+\tprove -wl \$(XTEST_FILES)
+endif
+EOM
+
+    return $orig;
+}
+1;


### PR DESCRIPTION
No convention but on IRC#smoke:
```
17:41:14    Bram | Is there a make target to run the tests in xt/?
19:26:26 abeltje | no make target for running tests in xt/; is there a convention for that?
19:29:36  ilmari | dzil has an `xtest` command to run them
```
So I named it `xtest` and used XTEST_FILES to select files to run:
 
       `make xtest TEST_VERBOSE=1 XTEST_FILES=xt/0*.t`
but this also works:

        `make xtest`

