### PR TITLE
Add '.mailmap' to ignore list of MANIFEST check

### DIFF
--- a/lib/Test/Smoke/SourceTree.pm
+++ b/lib/Test/Smoke/SourceTree.pm
@@ -222,7 +222,7 @@ sub check_MANIFEST {
     my %ignore = map {
         my $entry = $NOCASE ? uc $_ : $_;
         $entry => undef
-    } ( ".patch", "MANIFEST.SKIP", '.git', '.gitignore', @_ ),
+    } ( ".patch", "MANIFEST.SKIP", '.git', '.gitignore', '.mailmap', @_ ),
       keys %{ $self->_read_mani_file( 'MANIFEST.SKIP', 1 ) };
     $self->log_debug("Found %d entries in MANIFEST.SKIP", scalar(keys %ignore));
 


### PR DESCRIPTION
The '.mailmap' file is not included in the MANIFEST, it's also
special cased in perl5.git/t/porting/manifest.t.

The manifest test of Test::Smoke should also ignore it.
All reports currently contain:

	MANIFEST messages:
	  MANIFEST did not declare '.mailmap'

which is irrelevant noise.