### PR TITLE
Filter out the default msg in `user_skiped_tests`

### DIFF
--- a/lib/Test/Smoke/Reporter.pm
+++ b/lib/Test/Smoke/Reporter.pm
@@ -1034,7 +1034,11 @@ sub user_skipped_tests {
     if ($self->{skip_tests} && -f $self->{skip_tests} and open my $fh,
         "<", $self->{skip_tests})
     {
-        @skipped = map { chomp; "    $_" } <$fh>;
+        while (my $raw = <$fh>) {
+            next, if $raw =~ m/^# One test name on a line/;
+
+            push @skipped,  "    $raw";
+        }
         close $fh;
     }
     wantarray and return @skipped;


### PR DESCRIPTION
`bin/configsmoke.pl` adds a default message when creating the 'skip tests' file.

Filter out that message in the report to reduce some 'useless' info.

For reference: the 'skip tests' file is used by `...::Smoker::set_skip_tests`
which does some more filtering (skip comments, ...).

Exact Filtering that it does:

	    $raw =~ m/^\s*#/ and next;
	    $raw =~ s/(\S+).*/$1/s;
	    if ($raw !~ m/\.t$/ and $raw !~ m/test\.pl$/) {
	        next;
	    }

I opted not to do the same filtering and instead just filter the default
message. If there are comments in the file then they could be useful
to include in the report (i.e. if they explain why a test file is skipped)