### PR TITLE
Replace search.cpan.org URLs with metacpan.org URLs

### DIFF
--- a/README
+++ b/README
@@ -143,7 +143,7 @@ run time of Test::Smoke.
 
 =item B<Distribution>
 
-    http://search.cpan.org/dist/Test-Smoke/
+    http://metacpan.org/pod/Test::Smoke/
 
     https://github.com/abeltje/Test-Smoke
 

--- a/lib/Test/Smoke/FAQ
+++ b/lib/Test/Smoke/FAQ
@@ -74,7 +74,7 @@ perls:
 
 =over 4
 
-=item * with C<< $ENV{PERLIO}=stdio >> (allways)
+=item * with C<< $ENV{PERLIO}=stdio >> (always)
 
 =item * with C<< $ENV{PERLIO}=perlio >> (unless -Uuseperlio)
 

--- a/lib/Test/Smoke/FAQ
+++ b/lib/Test/Smoke/FAQ
@@ -30,7 +30,7 @@ as possible.
 
 =head2 Where is Test::Smoke?
 
-On CPAN and L<http://search.cpan.org/dist/Test-Smoke>
+On CPAN and L<http://metacpan.org/pod/Test::Smoke>
 
 =head2 What are these configuration files about?
 


### PR DESCRIPTION
... since search.cpan.org has been gone for several years now.